### PR TITLE
Fix header preview to use form state

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -21,7 +21,7 @@ import FooterEditor from '@blocks/forms/Footer'
 export default function BlockDetails({ block, data, onSave }) {
   const [form, setForm] = useState({})
   const { slug } = useParams()
-  const { site_name } = useSiteSettings()
+  const { site_name, data: siteData } = useSiteSettings()
 
   useEffect(() => {
     if (!block?.real_id) return
@@ -55,9 +55,18 @@ export default function BlockDetails({ block, data, onSave }) {
       )
     }
 
+    const previewProps = { settings: form }
+
+    if (block.type === 'header') {
+      previewProps.data = form
+      previewProps.commonSettings = siteData?.common || {}
+      previewProps.navigation =
+        siteData?.navigation?.filter(n => n.block_id === block.real_id && n.visible) || []
+    }
+
     return (
       <div>
-        <PreviewComponent settings={form} />
+        <PreviewComponent {...previewProps} />
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- provide site data in BlockDetails component
- send live field data to HeaderPreview

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68407fed88308331873a8be2c1f5b6cf