### PR TITLE
Fix header preview to use form state

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSiteSettings } from '@/context/SiteSettingsContext'
 import { headerSchema } from './headerSchema'
 import { headerDataSchema } from './headerDataSchema'
@@ -17,6 +17,11 @@ export default function HeaderEditor({ block, slug, onChange }) {
 
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
+
+  useEffect(() => {
+    setDataState(block?.data || {})
+    setSettingsState(block?.settings || {})
+  }, [block])
 
   const {
     handleFieldChange,

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
@@ -33,12 +33,19 @@ export default function HeaderEditor({ block, slug, onChange }) {
     siteData,
     site_name,
     setData,
-    onChange: (newSettings) => {
-      setSettingsState(newSettings)
-      onChange((prevBlockState) => ({
-        ...prevBlockState,
-        settings: newSettings,
-      }))
+    onChange: (update) => {
+      setSettingsState(update)
+      onChange(prevBlockState => {
+        const resolved =
+          typeof update === 'function'
+            ? update(prevBlockState.settings || {})
+            : update
+        return {
+          ...prevBlockState,
+          ...resolved,
+          settings: resolved,
+        }
+      })
     },
   })
 
@@ -55,13 +62,19 @@ export default function HeaderEditor({ block, slug, onChange }) {
     slug,
     site_name,
     setData,
-    onChange: (newData) => {
-      console.log('HeaderEditor: onChange вызван с newData:', newData)
-      setDataState(newData)
-      onChange((prevBlockState) => ({
-        ...prevBlockState,
-        data: newData,
-      }))
+    onChange: (update) => {
+      setDataState(update)
+      onChange(prevBlockState => {
+        const resolved =
+          typeof update === 'function'
+            ? update(prevBlockState.data || {})
+            : update
+        return {
+          ...prevBlockState,
+          ...resolved,
+          data: resolved,
+        }
+      })
     },
   })
 

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
@@ -7,18 +7,11 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
   const [resetButton, setResetButton] = useState(false)
 
   useEffect(() => {
-    const values = {}
-    for (const field of schema) {
-      values[field.key] =
-        data?.[field.key] !== undefined ? data[field.key] : field.default ?? ''
-    }
-
-    setInitialData(values)
-
-    const isChanged = schema.some(
-      (field) => data?.[field.key] !== values[field.key]
-    )
-    setReadyToCheck(isChanged)
+    // При открытии редактора фиксируем текущее состояние данных
+    // как исходное, чтобы кнопка "Сохранить" не отображалась
+    // пока пользователь не внесет изменения
+    setInitialData({ ...data })
+    setReadyToCheck(false)
   }, [block_id])
 
   const handleFieldChange = (key, value) => {

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -26,12 +26,14 @@ export default function BlockDetails({ block, data, onSave }) {
   useEffect(() => {
     if (!block?.real_id) return
 
-    console.log('📦 BlockDetails: Исходный пропс "block" (полный объект блока):', block)
+    const combinedSettings = { ...(data?.settings || data || {}), ...(block.settings || {}) }
+    const combinedData = { ...(data?.data || {}), ...(block.data || {}) }
+
     setForm({
-      ...block.settings,
-      ...block.data,
-      data: { ...block.data },
-      settings: { ...block.settings },
+      ...combinedSettings,
+      ...combinedData,
+      data: { ...combinedData },
+      settings: { ...combinedSettings },
       block_id: block.real_id,
       slug: block.slug,
       id: block.id,
@@ -40,8 +42,7 @@ export default function BlockDetails({ block, data, onSave }) {
       active: block.active,
       label: block.label,
     })
-    console.log('📦 BlockDetails: Инициализированное состояние формы (form):', form)
-  }, [block])
+  }, [block, data])
 
   if (!block || !block.real_id) {
     return <p className="text-gray-500 text-sm">❗ Выберите блок для редактирования</p>
@@ -73,8 +74,10 @@ export default function BlockDetails({ block, data, onSave }) {
     )
   }
 
+  const mergedBlock = { ...block, settings: form.settings, data: form.data }
+
   const sharedProps = {
-    block,
+    block: mergedBlock,
     data: form,
     onChange: setForm,
     slug,

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -21,7 +21,7 @@ import FooterEditor from '@blocks/forms/Footer'
 export default function BlockDetails({ block, data, onSave }) {
   const [form, setForm] = useState({})
   const { slug } = useParams()
-  const { site_name } = useSiteSettings()
+  const { site_name, data: siteData } = useSiteSettings()
 
   useEffect(() => {
     if (!block?.real_id) return
@@ -55,9 +55,18 @@ export default function BlockDetails({ block, data, onSave }) {
       )
     }
 
+    const previewProps = { settings: form }
+
+    if (block.type === 'header') {
+      previewProps.data = form
+      previewProps.commonSettings = siteData?.common || {}
+      previewProps.navigation =
+        siteData?.navigation?.filter(n => n.block_id === block.real_id && n.visible) || []
+    }
+
     return (
       <div>
-        <PreviewComponent settings={form} />
+        <PreviewComponent {...previewProps} />
       </div>
     )
   }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -60,6 +60,10 @@ export default function BlockDetails({ block, data, onSave }) {
 
     const previewProps = { settings: form.settings || form }
 
+    if (block.type === 'navigation') {
+      previewProps.settings = { ...(form.settings || {}) }
+    }
+
     if (block.type === 'header') {
       previewProps.data = form.data || form
       previewProps.commonSettings = siteData?.common || {}

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -30,6 +30,8 @@ export default function BlockDetails({ block, data, onSave }) {
     setForm({
       ...block.settings,
       ...block.data,
+      data: { ...block.data },
+      settings: { ...block.settings },
       block_id: block.real_id,
       slug: block.slug,
       id: block.id,
@@ -55,10 +57,10 @@ export default function BlockDetails({ block, data, onSave }) {
       )
     }
 
-    const previewProps = { settings: form }
+    const previewProps = { settings: form.settings || form }
 
     if (block.type === 'header') {
-      previewProps.data = form
+      previewProps.data = form.data || form
       previewProps.commonSettings = siteData?.common || {}
       previewProps.navigation =
         siteData?.navigation?.filter(n => n.block_id === block.real_id && n.visible) || []


### PR DESCRIPTION
## Summary
- provide site data in BlockDetails component
- send live field data to HeaderPreview

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68407fed88308331873a8be2c1f5b6cf