### PR TITLE
Fix header preview to use form state

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSiteSettings } from '@/context/SiteSettingsContext'
 import { headerSchema } from './headerSchema'
 import { headerDataSchema } from './headerDataSchema'
@@ -18,6 +18,11 @@ export default function HeaderEditor({ block, slug, onChange }) {
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
 
+  useEffect(() => {
+    setDataState(block?.data || {})
+    setSettingsState(block?.settings || {})
+  }, [block])
+
   const {
     handleFieldChange,
     handleSaveAppearance,
@@ -33,12 +38,19 @@ export default function HeaderEditor({ block, slug, onChange }) {
     siteData,
     site_name,
     setData,
-    onChange: (newSettings) => {
-      setSettingsState(newSettings)
-      onChange((prevBlockState) => ({
-        ...prevBlockState,
-        settings: newSettings,
-      }))
+    onChange: (update) => {
+      setSettingsState(update)
+      onChange(prevBlockState => {
+        const resolved =
+          typeof update === 'function'
+            ? update(prevBlockState.settings || {})
+            : update
+        return {
+          ...prevBlockState,
+          ...resolved,
+          settings: resolved,
+        }
+      })
     },
   })
 
@@ -55,13 +67,19 @@ export default function HeaderEditor({ block, slug, onChange }) {
     slug,
     site_name,
     setData,
-    onChange: (newData) => {
-      console.log('HeaderEditor: onChange вызван с newData:', newData)
-      setDataState(newData)
-      onChange((prevBlockState) => ({
-        ...prevBlockState,
-        data: newData,
-      }))
+    onChange: (update) => {
+      setDataState(update)
+      onChange(prevBlockState => {
+        const resolved =
+          typeof update === 'function'
+            ? update(prevBlockState.data || {})
+            : update
+        return {
+          ...prevBlockState,
+          ...resolved,
+          data: resolved,
+        }
+      })
     },
   })
 

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/ItemsEditor.jsx
@@ -20,6 +20,8 @@ export default function HeaderItemsEditor({
 
     if (showButton) {
       setInternalVisible(true)
+    } else {
+      setInternalVisible(false)
     }
   }, [showButton, resetButton])
 

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
@@ -7,18 +7,11 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
   const [resetButton, setResetButton] = useState(false)
 
   useEffect(() => {
-    const values = {}
-    for (const field of schema) {
-      values[field.key] =
-        data?.[field.key] !== undefined ? data[field.key] : field.default ?? ''
-    }
-
-    setInitialData(values)
-
-    const isChanged = schema.some(
-      (field) => data?.[field.key] !== values[field.key]
-    )
-    setReadyToCheck(isChanged)
+    // При открытии редактора фиксируем текущее состояние данных
+    // как исходное, чтобы кнопка "Сохранить" не отображалась
+    // пока пользователь не внесет изменения
+    setInitialData({ ...data })
+    setReadyToCheck(false)
   }, [block_id])
 
   const handleFieldChange = (key, value) => {

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
@@ -98,11 +98,15 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
 
   useEffect(() => {
     console.log('🟡 Сравниваем data и initialData:', data, initialData)
+    if (Object.keys(initialData).length === 0) {
+      setReadyToCheck(false)
+      return
+    }
     const changed = schema.some(
       (field) => data?.[field.key] !== initialData[field.key]
     )
     setReadyToCheck(changed)
-  }, [data])
+  }, [data, initialData])
 
   const showSaveButton = readyToCheck && hasDataChanged()
 

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -21,15 +21,19 @@ import FooterEditor from '@blocks/forms/Footer'
 export default function BlockDetails({ block, data, onSave }) {
   const [form, setForm] = useState({})
   const { slug } = useParams()
-  const { site_name } = useSiteSettings()
+  const { site_name, data: siteData } = useSiteSettings()
 
   useEffect(() => {
     if (!block?.real_id) return
 
-    console.log('📦 BlockDetails: Исходный пропс "block" (полный объект блока):', block)
+    const combinedSettings = { ...(data?.settings || data || {}), ...(block.settings || {}) }
+    const combinedData = { ...(data?.data || {}), ...(block.data || {}) }
+
     setForm({
-      ...block.settings,
-      ...block.data,
+      ...combinedSettings,
+      ...combinedData,
+      data: { ...combinedData },
+      settings: { ...combinedSettings },
       block_id: block.real_id,
       slug: block.slug,
       id: block.id,
@@ -38,8 +42,7 @@ export default function BlockDetails({ block, data, onSave }) {
       active: block.active,
       label: block.label,
     })
-    console.log('📦 BlockDetails: Инициализированное состояние формы (form):', form)
-  }, [block])
+  }, [block, data])
 
   if (!block || !block.real_id) {
     return <p className="text-gray-500 text-sm">❗ Выберите блок для редактирования</p>
@@ -55,15 +58,30 @@ export default function BlockDetails({ block, data, onSave }) {
       )
     }
 
+    const previewProps = { settings: form.settings || form }
+
+    if (block.type === 'navigation') {
+      previewProps.settings = { ...(form.settings || {}) }
+    }
+
+    if (block.type === 'header') {
+      previewProps.data = form.data || form
+      previewProps.commonSettings = siteData?.common || {}
+      previewProps.navigation =
+        siteData?.navigation?.filter(n => n.block_id === block.real_id && n.visible) || []
+    }
+
     return (
       <div>
-        <PreviewComponent settings={form} />
+        <PreviewComponent {...previewProps} />
       </div>
     )
   }
 
+  const mergedBlock = { ...block, settings: form.settings, data: form.data }
+
   const sharedProps = {
-    block,
+    block: mergedBlock,
     data: form,
     onChange: setForm,
     slug,


### PR DESCRIPTION
## Summary
- provide site data in BlockDetails component
- send live field data to HeaderPreview
- fix save button visibility in Header ItemsEditor

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68407fed88308331873a8be2c1f5b6cf