### PR TITLE
Add banner preview and editor

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/BannerPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/BannerPreview.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import { PreviewWrapper } from '@preview/PreviewWrapper'
+import { TopBanner } from './TopBanner'
+import { applyCssVariablesFromUiSchema } from '@preview/utils/applyCssVariables'
+import { useSiteSettings } from '@/context/SiteSettingsContext'
+
+export default function BannerPreview({ settings = {}, data = {}, commonSettings = {} }) {
+  const { data: globalSiteData } = useSiteSettings()
+  const [styleVars, setStyleVars] = useState({})
+
+  useEffect(() => {
+    if (!globalSiteData?.ui_schema) return
+
+    if (settings?.custom_appearance) {
+      const vars = {}
+      Object.entries(settings).forEach(([key, val]) => {
+        if (key.includes('color') || key.startsWith('bg_')) {
+          vars[`--${key.replace(/_/g, '-')}`] = val
+        }
+      })
+
+      const varsJson = JSON.stringify(vars)
+      const styleVarsJson = JSON.stringify(styleVars)
+
+      if (varsJson !== styleVarsJson) {
+        setStyleVars(vars)
+      }
+    } else {
+      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+      if (Object.keys(styleVars).length > 0) {
+        setStyleVars({})
+      }
+    }
+  }, [settings, globalSiteData?.ui_schema])
+
+  return (
+    <PreviewWrapper>
+      <div style={styleVars}>
+        <div className="max-w-full mx-auto text-[13px] leading-tight">
+          <TopBanner settings={settings} data={data} commonSettings={commonSettings} />
+        </div>
+      </div>
+    </PreviewWrapper>
+  )
+}

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
@@ -1,68 +1,125 @@
-import { useEffect, useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSiteSettings } from '@/context/SiteSettingsContext'
 import { bannerSchema } from './bannerSchema'
+import { bannerDataSchema } from './bannerDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
+
 import BannerItemsEditor from './ItemsEditor'
 import BannerAppearance from './Appearance'
-import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
+import BannerPreview from './BannerPreview'
 
-export default function BannerEditor({ block, data, onChange, slug }) {
+import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
+import { useBlockData } from '@blocks/forms/hooks/useBlockData'
+
+export default function BannerEditor({ block, slug, onChange }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
-  const [showToast, setShowToast] = useState(false)
+
+  const [dataState, setDataState] = useState(block?.data || {})
+  const [settingsState, setSettingsState] = useState(block?.settings || {})
+
+  useEffect(() => {
+    setDataState(block?.data || {})
+    setSettingsState(block?.settings || {})
+  }, [block])
 
   const {
     handleFieldChange,
     handleSaveAppearance,
-    showSavedToast,
-    resetButton,
-    showSaveButton,
+    showSavedToast: savedAppearance,
+    resetButton: resetAppearance,
+    showSaveButton: showAppearanceButton,
     uiDefaults,
   } = useBlockAppearance({
     schema: bannerSchema,
-    data,
+    data: settingsState,
     block_id,
     slug,
     siteData,
     site_name,
     setData,
-    onChange,
+    onChange: (update) => {
+      setSettingsState(update)
+      onChange(prev => {
+        const resolved = typeof update === 'function' ? update(prev.settings || {}) : update
+        return {
+          ...prev,
+          ...resolved,
+          settings: resolved,
+        }
+      })
+    },
+  })
+
+  const {
+    handleFieldChange: handleTextFieldChange,
+    handleSaveData,
+    showSavedToast: savedData,
+    resetButton: resetData,
+    showSaveButton: showDataButton,
+  } = useBlockData({
+    schema: bannerDataSchema,
+    data: dataState,
+    block_id,
+    slug,
+    site_name,
+    setData,
+    onChange: (update) => {
+      setDataState(update)
+      onChange(prev => {
+        const resolved = typeof update === 'function' ? update(prev.data || {}) : update
+        return {
+          ...prev,
+          ...resolved,
+          data: resolved,
+        }
+      })
+    },
   })
 
   return (
     <div className="space-y-6 relative">
-      {showToast && (
-        <div className="absolute top-0 right-0 bg-green-100 text-green-800 px-3 py-1 rounded shadow text-sm transition-opacity duration-300">
-          ✅ Порядок сохранён
+      {(savedAppearance || savedData) && (
+        <div className="text-green-600 text-sm font-medium">
+          ✅ {savedAppearance ? 'Внешний вид' : 'Содержимое'} сохранено
         </div>
       )}
-      {showSavedToast && (
-        <div className="text-green-600 text-sm font-medium">✅ Внешний вид сохранён</div>
-      )}
-
-      <div className="text-sm text-gray-500 italic pl-1">
-        ⚙️ Здесь можно настроить градиент, цвета текста и кнопки баннера
-      </div>
 
       <BannerItemsEditor
-        settings={data}
-        siteName={site_name}
-        siteData={siteData}
-        setData={setData}
-        onChange={onChange}
-        setShowToast={setShowToast}
+        schema={bannerDataSchema}
+        data={dataState}
+        onTextChange={handleTextFieldChange}
+        onSaveData={() => handleSaveData(dataState)}
+        showButton={showDataButton}
+        resetButton={resetData}
       />
+
+      <div className="text-sm text-gray-500 italic pl-1 pt-4 border-t">
+        🎨 Редактирование внешнего вида блока
+      </div>
 
       <BannerAppearance
         schema={bannerSchema}
-        settings={data}
+        settings={settingsState}
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
-        onSaveAppearance={handleSaveAppearance}
-        showButton={showSaveButton || data?.custom_appearance === false}
-        resetButton={resetButton}
+        onSaveAppearance={() => handleSaveAppearance(settingsState)}
+        showButton={showAppearanceButton || settingsState?.custom_appearance === false}
+        resetButton={resetAppearance}
         uiDefaults={uiDefaults}
       />
+
+      <div className="text-sm text-gray-500 italic pl-1 pt-4 border-t">
+        👁️ Живой предпросмотр блока
+      </div>
+
+      <div className="border rounded p-4 bg-white shadow-inner">
+        <BannerPreview
+          settings={settingsState}
+          data={dataState}
+          commonSettings={siteData?.common || {}}
+        />
+      </div>
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/ItemsEditor.jsx
@@ -1,7 +1,60 @@
-export default function BannerItemsEditor() {
+import { useEffect, useState } from 'react'
+import { fieldTypes } from '@/components/fields/fieldTypes'
+
+export default function BannerItemsEditor({
+  schema,
+  data,
+  onTextChange,
+  onSaveData,
+  showButton,
+  resetButton,
+  uiDefaults = {},
+}) {
+  const [internalVisible, setInternalVisible] = useState(false)
+
+  useEffect(() => {
+    if (resetButton) {
+      setInternalVisible(false)
+      return
+    }
+
+    if (showButton) {
+      setInternalVisible(true)
+    }
+  }, [showButton, resetButton])
+
+  const renderField = (field) => {
+    if (!field.editable) return null
+
+    const fieldKey = field.key
+    const textVal = data?.[fieldKey] ?? uiDefaults?.[fieldKey] ?? field.default ?? ''
+
+    const FieldComponent = fieldTypes[field.type] || fieldTypes.text
+    return (
+      <FieldComponent
+        {...field}
+        key={fieldKey}
+        value={textVal}
+        onChange={(val) => onTextChange(fieldKey, val)}
+        label={field.label}
+      />
+    )
+  }
+
   return (
-    <div className="text-gray-400 text-sm italic pl-1">
-      🔧 Редактирование текста и картинки баннера будет доступно позже
+    <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
+      {schema.map(renderField)}
+
+      {internalVisible && (
+        <div>
+          <button
+            onClick={onSaveData}
+            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+          >
+            💾 Сохранить содержимое блока
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/TopBanner.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/TopBanner.jsx
@@ -1,0 +1,106 @@
+import { ArrowRight } from 'lucide-react'
+import pizzaImg from '/images/1.png'
+
+export const TopBanner = ({ settings = {}, data = {}, commonSettings = {} }) => {
+  const isCustom = settings?.custom_appearance === true
+  const source = isCustom ? settings : commonSettings
+
+  const reverse = source?.reverse_layout === true
+  const layout = source?.layout_variant || 'wide'
+  const hoverEffect = source?.hover_effect !== false
+  const imgStyle = source?.img_style || 'default'
+
+  const titleText = data?.title_text || 'Дарим подарки'
+  const subtitleText = data?.subtitle_text || 'Выбирай на свой вкус из нашего ассортимента!'
+  const buttonText = data?.button_text || 'Подробнее'
+  const imageUrl = data?.image_url || pizzaImg
+
+  const getGradient = () => {
+    if (isCustom) {
+      const from = source?.bg_gradient_from || '#1976D2'
+      const to = source?.bg_gradient_to || '#90CAF9'
+      return `linear-gradient(to right, ${from}, ${to})`
+    }
+    const from = source?.background?.gradient_from || '#1976D2'
+    const to = source?.background?.gradient_to || '#90CAF9'
+    return `linear-gradient(to right, ${from}, ${to})`
+  }
+
+  const style = {
+    backgroundImage: getGradient(),
+    '--text-color': isCustom ? source?.text_color : source?.text?.primary || '#212121',
+    '--button-bg-color': isCustom ? source?.button_bg_color : source?.button?.bg || '#1976D2',
+    '--button-text-color': isCustom ? source?.button_text_color : source?.button?.text || '#FFFFFF',
+    '--button-hover-color': isCustom ? source?.button_hover_color : source?.button?.hover_bg || '#1259A8',
+  }
+
+  const imageClass = `relative z-10 w-[280px] lg:w-[320px] object-contain drop-shadow-[0_8px_24px_rgba(0,0,0,0.25)] transition duration-300 ${hoverEffect ? 'hover:scale-110' : ''} ${imgStyle === 'glow' ? 'animate-pulse-slow' : ''}`
+
+  return (
+    <div className={`w-full py-2 sm:py-3 ${layout === 'narrow' ? 'max-w-4xl mx-auto' : ''}`}>
+      <div
+        className="relative overflow-hidden mx-auto max-w-7xl rounded-3xl transition-shadow duration-300 hover:shadow-2xl"
+        style={style}
+      >
+        {/* \uD83D\uDCF1 \u041C\u043E\u0431\u0438\u043B\u044C\u043D\u0430\u044F \u0432\u0435\u0440\u0441\u0438\u044F */}
+        <div className="flex md:hidden items-center gap-4 px-4 py-4">
+          <img
+            src={imageUrl}
+            alt="Banner"
+            className="w-[90px] h-[90px] object-contain transition duration-300 hover:scale-110"
+          />
+          <div className="flex flex-col justify-center text-[var(--text-color)]">
+            <h2 className="text-lg font-extrabold">{titleText}</h2>
+            <p className="text-sm text-white/90 leading-tight">
+              {subtitleText}
+            </p>
+            <button className="mt-2 group inline-flex items-center gap-2 px-4 py-2 rounded-full font-semibold text-xs shadow transition bg-[var(--button-bg-color)] text-[var(--button-text-color)] hover:bg-[var(--button-hover-color)]">
+              {buttonText}
+              <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+            </button>
+          </div>
+        </div>
+
+        {/* \uD83D\uDCBB \u0414\u0435\u0441\u043A\u0442\u043E\u043F\u043D\u0430\u044F \u0432\u0435\u0440\u0441\u0438\u044F */}
+        <div className="hidden md:flex items-center justify-between px-10 lg:px-16 py-8 gap-8">
+          {!reverse && (
+            <div className="w-1/2 text-left space-y-4 z-10 text-[var(--text-color)]">
+              <h2 className="text-3xl md:text-5xl font-extrabold drop-shadow transition duration-300 hover:scale-105">
+                {titleText}
+              </h2>
+              <p className="text-lg md:text-xl text-white/90 transition duration-300 hover:scale-105">
+                {subtitleText}
+              </p>
+              <button className="group inline-flex items-center gap-2 px-6 py-3 rounded-full font-semibold text-sm shadow transition duration-300 hover:scale-105 bg-[var(--button-bg-color)] text-[var(--button-text-color)] hover:bg-[var(--button-hover-color)]">
+                {buttonText}
+                <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
+              </button>
+            </div>
+          )}
+          <div className="relative w-1/2 flex justify-center">
+            <div className="absolute w-60 h-60 bg-white/20 rounded-full blur-2xl z-0 animate-pulse-slow" />
+            <img
+              src={imageUrl}
+              alt="Banner"
+              className={imageClass}
+            />
+          </div>
+          {reverse && (
+            <div className="w-1/2 text-left space-y-4 z-10 text-[var(--text-color)]">
+              <h2 className="text-3xl md:text-5xl font-extrabold drop-shadow transition duration-300 hover:scale-105">
+                {titleText}
+              </h2>
+              <p className="text-lg md:text-xl text-white/90 transition duration-300 hover:scale-105">
+                {subtitleText}
+              </p>
+              <button className="group inline-flex items-center gap-2 px-6 py-3 rounded-full font-semibold text-sm shadow transition duration-300 hover:scale-105 bg-[var(--button-bg-color)] text-[var(--button-text-color)] hover:bg-[var(--button-hover-color)]">
+                {buttonText}
+                <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/bannerDataSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/bannerDataSchema.js
@@ -1,0 +1,30 @@
+export const bannerDataSchema = [
+  {
+    key: 'title_text',
+    label: 'Заголовок',
+    type: 'text',
+    default: 'Дарим подарки',
+    editable: true,
+  },
+  {
+    key: 'subtitle_text',
+    label: 'Подзаголовок',
+    type: 'text',
+    default: 'Выбирай на свой вкус из нашего ассортимента!',
+    editable: true,
+  },
+  {
+    key: 'button_text',
+    label: 'Текст кнопки',
+    type: 'text',
+    default: 'Подробнее',
+    editable: true,
+  },
+  {
+    key: 'image_url',
+    label: 'Изображение',
+    type: 'image',
+    default: '/images/1.png',
+    editable: true,
+  },
+]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -71,6 +71,11 @@ export default function BlockDetails({ block, data, onSave }) {
         siteData?.navigation?.filter(n => n.block_id === block.real_id && n.visible) || []
     }
 
+    if (block.type === 'banner') {
+      previewProps.data = form.data || form
+      previewProps.commonSettings = siteData?.common || {}
+    }
+
     return (
       <div>
         <PreviewComponent {...previewProps} />

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/blockMap.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/blockMap.js
@@ -1,9 +1,11 @@
 import NavigationPreview from '@blocks/forms/Navigation/NavigationPreview'
 import HeaderPreview from '@blocks/forms/Header/HeaderPreview'
+import BannerPreview from '@blocks/forms/Banner/BannerPreview'
 
 export const previewBlocks = {
   navigation: NavigationPreview,
   header: HeaderPreview, // ✅
+  banner: BannerPreview,
 }
 
 


### PR DESCRIPTION
## Summary
- implement TopBanner component and preview
- support editing banner data
- wire preview blocks map and details to banner

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684105fa34cc8331a78151e4a94600d6