### PR TITLE
Add QuickInfo preview support

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
@@ -1,32 +1,80 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSiteSettings } from '@/context/SiteSettingsContext'
 import { quickInfoSchema } from './quickInfoSchema'
+import { quickInfoDataSchema } from './quickInfoDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import QuickInfoItemsEditor from './ItemsEditor'
 import QuickInfoAppearance from './Appearance'
+import QuickInfoPreview from './QuickInfoPreview'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
+import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
-export default function QuickInfoEditor({ block, data, onChange, slug }) {
+export default function QuickInfoEditor({ block, slug, onChange }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
+  const [dataState, setDataState] = useState(block?.data || {})
+  const [settingsState, setSettingsState] = useState(block?.settings || {})
   const [showToast, setShowToast] = useState(false)
+
+  useEffect(() => {
+    setDataState(block?.data || {})
+    setSettingsState(block?.settings || {})
+  }, [block])
 
   const {
     handleFieldChange,
     handleSaveAppearance,
-    showSavedToast,
-    resetButton,
-    showSaveButton,
+    showSavedToast: savedAppearance,
+    resetButton: resetAppearance,
+    showSaveButton: showAppearanceButton,
     uiDefaults,
   } = useBlockAppearance({
     schema: quickInfoSchema,
-    data,
+    data: settingsState,
     block_id,
     slug,
     siteData,
     site_name,
     setData,
-    onChange,
+    onChange: (update) => {
+      setSettingsState(update)
+      onChange(prev => {
+        const resolved =
+          typeof update === 'function' ? update(prev.settings || {}) : update
+        return {
+          ...prev,
+          ...resolved,
+          settings: resolved,
+        }
+      })
+    },
+  })
+
+  const {
+    handleFieldChange: handleTextFieldChange,
+    handleSaveData,
+    showSavedToast: savedData,
+    resetButton: resetData,
+    showSaveButton: showDataButton,
+  } = useBlockData({
+    schema: quickInfoDataSchema,
+    data: dataState,
+    block_id,
+    slug,
+    site_name,
+    setData,
+    onChange: (update) => {
+      setDataState(update)
+      onChange(prev => {
+        const resolved =
+          typeof update === 'function' ? update(prev.data || {}) : update
+        return {
+          ...prev,
+          ...resolved,
+          data: resolved,
+        }
+      })
+    },
   })
 
   return (
@@ -36,8 +84,10 @@ export default function QuickInfoEditor({ block, data, onChange, slug }) {
           ✅ Порядок сохранён
         </div>
       )}
-      {showSavedToast && (
-        <div className="text-green-600 text-sm font-medium">✅ Внешний вид сохранён</div>
+      {(savedAppearance || savedData) && (
+        <div className="text-green-600 text-sm font-medium">
+          ✅ {savedAppearance ? 'Внешний вид' : 'Содержимое'} сохранено
+        </div>
       )}
 
       <div className="text-sm text-gray-500 italic pl-1">
@@ -45,7 +95,7 @@ export default function QuickInfoEditor({ block, data, onChange, slug }) {
       </div>
 
       <QuickInfoItemsEditor
-        settings={data}
+        settings={settingsState}
         siteName={site_name}
         siteData={siteData}
         setData={setData}
@@ -55,14 +105,26 @@ export default function QuickInfoEditor({ block, data, onChange, slug }) {
 
       <QuickInfoAppearance
         schema={quickInfoSchema}
-        settings={data}
+        settings={settingsState}
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
-        onSaveAppearance={handleSaveAppearance}
-        showButton={showSaveButton || data?.custom_appearance === false}
-        resetButton={resetButton}
+        onSaveAppearance={() => handleSaveAppearance(settingsState)}
+        showButton={showAppearanceButton || settingsState?.custom_appearance === false}
+        resetButton={resetAppearance}
         uiDefaults={uiDefaults}
       />
+
+      <div className="text-sm text-gray-500 italic pl-1 pt-4 border-t">
+        👁️ Живой предпросмотр блока
+      </div>
+
+      <div className="border rounded p-4 bg-white shadow-inner">
+        <QuickInfoPreview
+          settings={settingsState}
+          data={dataState}
+          commonSettings={siteData?.common || {}}
+        />
+      </div>
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfo.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfo.jsx
@@ -1,0 +1,130 @@
+import React from 'react'
+
+export const QuickInfo = ({ settings = {}, data = {}, commonSettings = {} }) => {
+  const isCustom = settings?.custom_appearance === true
+
+  const defaultQuickInfoSettings = {
+    gap: 24,
+    grid_cols: 4,
+    border_radius: 12,
+    font_size_title: 14,
+    font_size_desc: 16,
+    card_bg_color: '#FFFFFF',
+    card_border_color: '#E5E7EB',
+    card_variant: 'flat',
+    show_cards: true,
+  }
+
+  const source = isCustom
+    ? settings
+    : {
+        ...defaultQuickInfoSettings,
+        bg_color: commonSettings.background?.surface,
+        title_color: commonSettings.text?.secondary,
+        desc_color: commonSettings.text?.accent,
+        text_color: commonSettings.text?.primary,
+      }
+
+  const bgColor = source?.bg_color || '#F3F4F6'
+  const titleColor = source?.title_color || '#6B7280'
+  const descColor = source?.desc_color || '#1976D2'
+  const gap = source?.gap || 24
+  const cols = source?.grid_cols || 4
+  const borderRadius = source?.border_radius || 12
+  const fontSizeTitle = source?.font_size_title || 14
+  const fontSizeDesc = source?.font_size_desc || 16
+  const cardBg = source?.card_bg_color || '#FFFFFF'
+  const cardBorder = source?.card_border_color || '#E5E7EB'
+  const variant = source?.card_variant || 'flat'
+  const showCards = source?.show_cards !== false
+
+  const defaultItems = [
+    { title: 'Мин. заказ на доставку', description: 'от 500 руб.' },
+    { title: 'Стоимость доставки', description: 'от 100 руб.' },
+    { title: 'Время доставки', description: 'до 59 мин.' },
+    { title: 'Скидка за самовывоз', description: '−10%' },
+  ]
+
+  const items = (() => {
+    if (
+      data?.title1 ||
+      data?.desc1 ||
+      data?.title2 ||
+      data?.desc2 ||
+      data?.title3 ||
+      data?.desc3 ||
+      data?.title4 ||
+      data?.desc4
+    ) {
+      return [
+        { title: data.title1, description: data.desc1 },
+        { title: data.title2, description: data.desc2 },
+        { title: data.title3, description: data.desc3 },
+        { title: data.title4, description: data.desc4 },
+      ]
+    }
+    return defaultItems
+  })()
+
+  const hexToRgba = (hex, alpha = 0.6) => {
+    if (!hex || hex[0] !== '#' || (hex.length !== 7 && hex.length !== 4)) return hex
+    let r, g, b
+    if (hex.length === 7) {
+      r = parseInt(hex.slice(1, 3), 16)
+      g = parseInt(hex.slice(3, 5), 16)
+      b = parseInt(hex.slice(5, 7), 16)
+    } else {
+      r = parseInt(hex[1] + hex[1], 16)
+      g = parseInt(hex[2] + hex[2], 16)
+      b = parseInt(hex[3] + hex[3], 16)
+    }
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`
+  }
+
+  return (
+    <div
+      className="hidden sm:grid w-full mt-4 mb-6 text-center px-2 py-3"
+      style={{
+        backgroundColor: hexToRgba(bgColor),
+        borderRadius: `${borderRadius}px`,
+        gap: `${gap}px`,
+        gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+      }}
+    >
+      {items.map((item, i) => (
+        <div
+          key={i}
+          className={`space-y-1 px-2 py-2 ${
+            !showCards
+              ? ''
+              : variant === 'border'
+              ? 'border'
+              : variant === 'hover-shadow'
+              ? 'transition hover:shadow-md'
+              : ''
+          }`}
+          style={{
+            backgroundColor: showCards ? cardBg : 'transparent',
+            borderColor: cardBorder,
+            borderRadius: `${borderRadius}px`,
+          }}
+        >
+          <div
+            className="leading-tight"
+            style={{ color: hexToRgba(titleColor, 0.6), fontSize: `${fontSizeTitle}px` }}
+          >
+            {item.title}
+          </div>
+          <div
+            className="font-semibold"
+            style={{ color: descColor, fontSize: `${fontSizeDesc}px` }}
+          >
+            {item.description}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default QuickInfo

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfoPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfoPreview.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { PreviewWrapper } from '@preview/PreviewWrapper'
+import QuickInfo from './QuickInfo'
+import { applyCssVariablesFromUiSchema } from '@preview/utils/applyCssVariables'
+import { useSiteSettings } from '@/context/SiteSettingsContext'
+
+export default function QuickInfoPreview({ settings = {}, data = {}, commonSettings = {} }) {
+  const { data: globalSiteData } = useSiteSettings()
+  const [styleVars, setStyleVars] = useState({})
+
+  useEffect(() => {
+    if (!globalSiteData?.ui_schema) return
+
+    if (settings?.custom_appearance) {
+      const vars = {}
+      Object.entries(settings).forEach(([key, val]) => {
+        if (key.includes('color') || key.startsWith('bg_')) {
+          vars[`--${key.replace(/_/g, '-')}`] = val
+        }
+      })
+
+      const varsJson = JSON.stringify(vars)
+      const styleVarsJson = JSON.stringify(styleVars)
+
+      if (varsJson !== styleVarsJson) {
+        setStyleVars(vars)
+      }
+    } else {
+      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+      if (Object.keys(styleVars).length > 0) {
+        setStyleVars({})
+      }
+    }
+  }, [settings, globalSiteData?.ui_schema])
+
+  return (
+    <PreviewWrapper>
+      <div style={styleVars}>
+        <QuickInfo settings={settings} data={data} commonSettings={commonSettings} />
+      </div>
+    </PreviewWrapper>
+  )
+}

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/quickInfoDataSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/quickInfoDataSchema.js
@@ -1,0 +1,10 @@
+export const quickInfoDataSchema = [
+  { key: 'title1', label: 'Заголовок 1', type: 'text', default: 'Мин. заказ на доставку', editable: true },
+  { key: 'desc1', label: 'Описание 1', type: 'text', default: 'от 500 руб.', editable: true },
+  { key: 'title2', label: 'Заголовок 2', type: 'text', default: 'Стоимость доставки', editable: true },
+  { key: 'desc2', label: 'Описание 2', type: 'text', default: 'от 100 руб.', editable: true },
+  { key: 'title3', label: 'Заголовок 3', type: 'text', default: 'Время доставки', editable: true },
+  { key: 'desc3', label: 'Описание 3', type: 'text', default: 'до 59 мин.', editable: true },
+  { key: 'title4', label: 'Заголовок 4', type: 'text', default: 'Скидка за самовывоз', editable: true },
+  { key: 'desc4', label: 'Описание 4', type: 'text', default: '−10%', editable: true },
+]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -71,6 +71,11 @@ export default function BlockDetails({ block, data, onSave }) {
         siteData?.navigation?.filter(n => n.block_id === block.real_id && n.visible) || []
     }
 
+    if (block.type === 'info') {
+      previewProps.data = form.data || form
+      previewProps.commonSettings = siteData?.common || {}
+    }
+
     return (
       <div>
         <PreviewComponent {...previewProps} />

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/blockMap.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/blockMap.js
@@ -1,9 +1,11 @@
 import NavigationPreview from '@blocks/forms/Navigation/NavigationPreview'
 import HeaderPreview from '@blocks/forms/Header/HeaderPreview'
+import QuickInfoPreview from '@blocks/forms/QuickInfo/QuickInfoPreview'
 
 export const previewBlocks = {
   navigation: NavigationPreview,
   header: HeaderPreview, // ✅
+  info: QuickInfoPreview,
 }
 
 


### PR DESCRIPTION
## Summary
- add QuickInfo block component and preview component
- create data schema for QuickInfo block
- enhance QuickInfo editor to handle data state and preview like header
- wire QuickInfo preview in preview map and preview details

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841066baa7883318fef9dcd25613476