### PR TITLE
Adjust BlocksEditor spacing and sticky preview

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
@@ -75,7 +75,7 @@ export default function PageEditor() {
   const selectedData = selectedBlock ? blockDataMap[selectedBlock.real_id] || {} : {}
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="-mt-6 p-6 pt-0 space-y-4">
       <PageSelectHeader slug={slug} data={data} />
       <div className="flex gap-6">
         <BlockListSidebar

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/PageSelectHeader.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/PageSelectHeader.jsx
@@ -23,9 +23,6 @@ export default function PageSelectHeader({ slug, data }) {
         </select>
         {pageId && <span className="text-sm text-gray-500">ID страницы: {pageId}</span>}
       </div>
-      <Link to={`/settings/${domain}/pages`} className="text-blue-600 hover:underline text-sm">
-        ← Назад к списку
-      </Link>
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -132,7 +132,7 @@ export default function BlockDetails({ block, data, onSave }) {
   return (
     <div className="space-y-6">
       {showPreview ? (
-        <div className="sticky top-0 z-10 bg-white pt-2 pb-4">
+        <div className="sticky top-14 z-10 bg-white pt-2 pb-4">
           <div className="flex justify-between items-center mb-2">
             <div className="text-sm text-gray-500">🔍 Предпросмотр</div>
             <button
@@ -145,7 +145,7 @@ export default function BlockDetails({ block, data, onSave }) {
           {renderPreview()}
         </div>
       ) : (
-        <div className="sticky top-0 z-10 bg-white pt-2 pb-2">
+        <div className="sticky top-14 z-10 bg-white pt-2 pb-2">
           <button
             onClick={() => setShowPreview(true)}
             className="text-xs text-blue-600 hover:underline"


### PR DESCRIPTION
## Summary
- remove unused back link from BlocksEditor header
- offset preview sticky panels to sit below the admin header
- pull editor layout up to align with the top of the page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68416f15be38833196bd71174a7d0938