### PR TITLE
Fetch library data from backend

### DIFF
--- a/src/cloud/CloudSidebar.jsx
+++ b/src/cloud/CloudSidebar.jsx
@@ -1,11 +1,15 @@
 // src/cloud/CloudSidebar.jsx
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export default function CloudSidebar({ active, onSelectCategory, groups }) {
-  const [openGroups, setOpenGroups] = useState(() =>
-    Object.fromEntries(groups.map(g => [g.title, g.title === 'Системные']))
-  )
+  const [openGroups, setOpenGroups] = useState({})
+
+  useEffect(() => {
+    setOpenGroups(
+      Object.fromEntries(groups.map(g => [g.title, g.title === 'Системные']))
+    )
+  }, [groups])
 
   const toggleGroup = (title) => {
     setOpenGroups(prev => ({ ...prev, [title]: !prev[title] }))

--- a/src/cloud/hooks/useTemplateGallery.js
+++ b/src/cloud/hooks/useTemplateGallery.js
@@ -1,25 +1,36 @@
 // src/cloud/hooks/useTemplateGallery.js
+import { useEffect, useState } from 'react'
 
 export default function useTemplateGallery() {
-  const groups = [
-    {
-      title: 'Пиццы',
-      categories: ['classic', 'veggie', 'pepperoni'],
-    },
-    {
-      title: 'Напитки',
-      categories: ['cola', 'juice', 'water'],
-    },
-  ]
+  const [groups, setGroups] = useState([])
+  const [files, setFiles] = useState([])
 
-  const files = [
-    { id: 'g1', name: 'classic1.jpg', url: 'https://via.placeholder.com/150?text=Classic+Pizza', category: 'classic' },
-    { id: 'g2', name: 'veggie1.jpg', url: 'https://via.placeholder.com/150?text=Veggie+Pizza', category: 'veggie' },
-    { id: 'g3', name: 'pepperoni1.jpg', url: 'https://via.placeholder.com/150?text=Pepperoni', category: 'pepperoni' },
-    { id: 'g4', name: 'cola.jpg', url: 'https://via.placeholder.com/150?text=Cola', category: 'cola' },
-    { id: 'g5', name: 'juice.jpg', url: 'https://via.placeholder.com/150?text=Juice', category: 'juice' },
-    { id: 'g6', name: 'water.jpg', url: 'https://via.placeholder.com/150?text=Water', category: 'water' },
-  ]
+  useEffect(() => {
+    async function fetchLibrary() {
+      try {
+        const res = await fetch(`${import.meta.env.VITE_API_URL}/cloud/library`)
+        const data = await res.json()
+
+        if (data.groups) {
+          setGroups(data.groups)
+        }
+
+        if (data.files) {
+          const base = import.meta.env.VITE_LIBRARY_ASSETS_URL
+          setFiles(
+            data.files.map(img => ({
+              ...img,
+              url: base + img.url,
+            }))
+          )
+        }
+      } catch (err) {
+        console.error('Failed to load library', err)
+      }
+    }
+
+    fetchLibrary()
+  }, [])
 
   return { groups, files }
 }


### PR DESCRIPTION
## Summary
- load library images via `VITE_API_URL` and `VITE_LIBRARY_ASSETS_URL`
- refresh sidebar state when library groups change

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842e1dfe2dc8331ade8952d5d685d94