### PR TITLE
Add site image management API integration

### DIFF
--- a/src/cloud/CloudGrid.jsx
+++ b/src/cloud/CloudGrid.jsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
 import CloudFileCard from './CloudFileCard'
 import ImagePreviewModal from './ImagePreviewModal'
-import { Search } from 'lucide-react'
+import { Search, Trash2, Pencil } from 'lucide-react'
 
-export default function CloudGrid({ files, selected, onSelect }) {
+export default function CloudGrid({ files, selected, onSelect, onDelete, onEdit }) {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false)
   const [previewIndex, setPreviewIndex] = useState(0)
 
@@ -29,15 +29,39 @@ export default function CloudGrid({ files, selected, onSelect }) {
                 alt={file.filename}
                 className="max-h-full max-w-full object-contain"
               />
-              <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  handlePreview(i)
-                }}
-                className="absolute top-1 right-1 bg-white rounded-full p-1 shadow opacity-0 group-hover:opacity-100 transition"
-              >
-                <Search size={16} />
-              </button>
+              <div className="absolute top-1 right-1 flex gap-1 opacity-0 group-hover:opacity-100 transition">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handlePreview(i)
+                  }}
+                  className="bg-white rounded-full p-1 shadow"
+                >
+                  <Search size={16} />
+                </button>
+                {onEdit && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onEdit(file)
+                    }}
+                    className="bg-white rounded-full p-1 shadow"
+                  >
+                    <Pencil size={16} />
+                  </button>
+                )}
+                {onDelete && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onDelete(file)
+                    }}
+                    className="bg-white rounded-full p-1 shadow"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                )}
+              </div>
             </div>
             <div className="px-2 py-1 w-full text-xs text-center text-gray-700 truncate border-t">
               {file.filename}

--- a/src/cloud/CloudModal.jsx
+++ b/src/cloud/CloudModal.jsx
@@ -19,6 +19,11 @@ export default function CloudModal({ isOpen, category, onSelect }) {
     used,
     limit,
     handleUploadClick,
+    uploadInputRef,
+    handleInputChange,
+    createCategory,
+    deleteImage,
+    updateImage,
   } = useCloudStorage()
 
   const {
@@ -55,6 +60,13 @@ export default function CloudModal({ isOpen, category, onSelect }) {
       onClose={() => onSelect(null)}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30"
     >
+      <input
+        ref={uploadInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={handleInputChange}
+      />
       <div className="bg-white rounded-lg w-full max-w-4xl h-[32rem] flex flex-col shadow-lg">
         <div className="border-b px-4 pt-4">
           <div className="flex justify-between items-start">
@@ -91,7 +103,7 @@ export default function CloudModal({ isOpen, category, onSelect }) {
                   Сгенерировать с помощью ИИ
                 </button>
                 <button
-                  onClick={handleUploadClick}
+                  onClick={() => handleUploadClick(activeCategory)}
                   className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
                 >
                   Загрузить с компьютера
@@ -108,9 +120,21 @@ export default function CloudModal({ isOpen, category, onSelect }) {
             groups={currentGroups}
             active={activeCategory}
             onSelectCategory={setActiveCategory}
+            onAddCategory={createCategory}
           />
           <div className="flex-1 p-4 space-y-4 overflow-y-auto">
-            <CloudGrid files={filtered} selected={selected} onSelect={setSelected} />
+            <CloudGrid
+              files={filtered}
+              selected={selected}
+              onSelect={setSelected}
+              onDelete={deleteImage}
+              onEdit={(file) => {
+                const alt = window.prompt('Alt text', file.alt_text || '')
+                if (alt !== null) {
+                  updateImage(file.id, { alt_text: alt })
+                }
+              }}
+            />
           </div>
         </div>
 

--- a/src/cloud/CloudModal.jsx
+++ b/src/cloud/CloudModal.jsx
@@ -127,13 +127,16 @@ export default function CloudModal({ isOpen, category, onSelect }) {
               files={filtered}
               selected={selected}
               onSelect={setSelected}
-              onDelete={deleteImage}
-              onEdit={(file) => {
-                const alt = window.prompt('Alt text', file.alt_text || '')
-                if (alt !== null) {
-                  updateImage(file.id, { alt_text: alt })
-                }
-              }}
+              onDelete={activeTab === 'site' ? deleteImage : undefined}
+              onEdit=
+                {activeTab === 'site'
+                  ? (file) => {
+                      const alt = window.prompt('Alt text', file.alt_text || '')
+                      if (alt !== null) {
+                        updateImage(file.id, { alt_text: alt })
+                      }
+                    }
+                  : undefined}
             />
           </div>
         </div>

--- a/src/cloud/CloudSidebar.jsx
+++ b/src/cloud/CloudSidebar.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-export default function CloudSidebar({ active, onSelectCategory, groups }) {
+export default function CloudSidebar({ active, onSelectCategory, groups, onAddCategory }) {
   const [openGroups, setOpenGroups] = useState({})
 
   useEffect(() => {
@@ -23,7 +23,7 @@ export default function CloudSidebar({ active, onSelectCategory, groups }) {
         className="w-full border rounded px-2 py-1 text-sm"
       />
 
-      {groups.map(group => (
+      {groups.map((group) => (
         <div key={group.title} className="space-y-1">
           <button
             onClick={() => toggleGroup(group.title)}
@@ -35,12 +35,12 @@ export default function CloudSidebar({ active, onSelectCategory, groups }) {
 
           {openGroups[group.title] && group.children && (
             <div className="space-y-1">
-              {group.children.map(sub => (
+              {group.children.map((sub) => (
                 <button
-                  key={sub.title}
-                  onClick={() => onSelectCategory?.(sub.categories[0])}
+                  key={sub.id}
+                  onClick={() => onSelectCategory?.(sub.id)}
                   className={`text-left block w-full text-sm px-2 py-1 rounded hover:bg-gray-100 ${
-                    active === sub.categories[0] ? 'bg-gray-200 font-semibold' : ''
+                    active === sub.id ? 'bg-gray-200 font-semibold' : ''
                   }`}
                 >
                   {sub.title}
@@ -50,6 +50,18 @@ export default function CloudSidebar({ active, onSelectCategory, groups }) {
           )}
         </div>
       ))}
+
+      {onAddCategory && (
+        <button
+          onClick={() => {
+            const name = window.prompt('Название категории')
+            if (name) onAddCategory(name)
+          }}
+          className="text-sm text-blue-600 hover:underline mt-4"
+        >
+          + Добавить категорию
+        </button>
+      )}
     </div>
   )
 }

--- a/src/cloud/hooks/useCloudStorage.js
+++ b/src/cloud/hooks/useCloudStorage.js
@@ -33,7 +33,11 @@ export default function useCloudStorage() {
         grouped[parent].push({ id: cat.id, title: cat.description || cat.name })
         if (cat.images) {
           cat.images.forEach((img) => {
-            allFiles.push({ ...img, category: cat.id })
+            allFiles.push({
+              ...img,
+              category: cat.id,
+              url: API_URL + img.url,
+            })
           })
         }
       }
@@ -85,7 +89,10 @@ export default function useCloudStorage() {
         )
         if (res.ok) {
           const img = await res.json()
-          setFiles((prev) => [...prev, { ...img, category: categoryId }])
+          setFiles((prev) => [
+            ...prev,
+            { ...img, category: categoryId, url: API_URL + img.url },
+          ])
         }
       } catch (err) {
         console.error('Upload failed', err)

--- a/src/cloud/hooks/useCloudStorage.js
+++ b/src/cloud/hooks/useCloudStorage.js
@@ -1,35 +1,158 @@
-// src/cloud/hooks/useCloudStorage.js
-
-import { useState } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useSiteSettings } from '@/context/SiteSettingsContext'
 
 export default function useCloudStorage() {
+  const { site_name } = useSiteSettings()
+  const API_URL = import.meta.env.VITE_API_URL
+
+  const [groups, setGroups] = useState([])
+  const [files, setFiles] = useState([])
   const [selected, setSelected] = useState(null)
+  const [used, setUsed] = useState(0)
+  const [limit, setLimit] = useState(0)
 
-  const groups = [
-    {
-      title: 'Системные',
-      categories: ['logo', 'banners', 'icons'],
-    },
-    {
-      title: 'Товары',
-      categories: ['pizza', 'rolls', 'drinks'],
-    },
-  ]
+  const uploadInputRef = useRef(null)
 
-  const files = [
-    { id: 1, name: 'logo1.png', url: 'https://via.placeholder.com/150', category: 'logo' },
-    { id: 2, name: 'logo2.png', url: 'https://via.placeholder.com/150', category: 'logo' },
-    { id: 3, name: 'pizza1.png', url: 'https://via.placeholder.com/150', category: 'pizza' },
-    { id: 4, name: 'pizza2.png', url: 'https://via.placeholder.com/150', category: 'pizza' },
-    { id: 5, name: 'drink1.png', url: 'https://via.placeholder.com/150', category: 'drinks' },
-    { id: 6, name: 'drink2.png', url: 'https://via.placeholder.com/150', category: 'drinks' },
-    { id: 7, name: 'drink3.png', url: 'https://via.placeholder.com/150', category: 'drinks' },
-    { id: 8, name: 'other.png', url: 'https://via.placeholder.com/150', category: 'logo' },
-    { id: 9, name: 'sample.png', url: 'https://via.placeholder.com/150', category: 'pizza' },
-  ]
+  const fetchData = useCallback(async () => {
+    if (!site_name) return
+    try {
+      const res = await fetch(`${API_URL}/images/categories/?site_name=${site_name}`, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('access_token')}`,
+        },
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Failed to load categories')
+      const data = await res.json()
 
-  const used = 73.2
-  const limit = 200
+      const grouped = {}
+      const allFiles = []
+      for (const cat of data) {
+        const parent = cat.category_type === 'products' ? 'ТОВАРЫ' : 'СИСТЕМНЫЕ'
+        if (!grouped[parent]) grouped[parent] = []
+        grouped[parent].push({ id: cat.id, title: cat.description || cat.name })
+        if (cat.images) {
+          cat.images.forEach((img) => {
+            allFiles.push({ ...img, category: cat.id })
+          })
+        }
+      }
+      setGroups(
+        Object.entries(grouped).map(([title, children]) => ({ title, children }))
+      )
+      setFiles(allFiles)
+    } catch (err) {
+      console.error('Failed to fetch site files', err)
+    }
+  }, [API_URL, site_name])
 
-  return { groups, files, selected, setSelected, used, limit }
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const createCategory = async (name) => {
+    try {
+      const res = await fetch(`${API_URL}/images/categories/?site_name=${site_name}`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('access_token')}`,
+        },
+        body: JSON.stringify({ name }),
+      })
+      if (res.ok) await fetchData()
+    } catch (err) {
+      console.error('Failed to create category', err)
+    }
+  }
+
+  const uploadFiles = async (filesList, categoryId) => {
+    for (const file of filesList) {
+      const formData = new FormData()
+      formData.append('file', file)
+      try {
+        const res = await fetch(
+          `${API_URL}/images/?site_name=${site_name}&category_id=${categoryId}&category=${categoryId}`,
+          {
+            method: 'POST',
+            credentials: 'include',
+            headers: {
+              Authorization: `Bearer ${localStorage.getItem('access_token')}`,
+            },
+            body: formData,
+          }
+        )
+        if (res.ok) {
+          const img = await res.json()
+          setFiles((prev) => [...prev, { ...img, category: categoryId }])
+        }
+      } catch (err) {
+        console.error('Upload failed', err)
+      }
+    }
+  }
+
+  const deleteImage = async (id) => {
+    try {
+      const res = await fetch(`${API_URL}/images/${id}?site_name=${site_name}`, {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('access_token')}`,
+        },
+      })
+      if (res.ok) setFiles((prev) => prev.filter((f) => f.id !== id))
+    } catch (err) {
+      console.error('Failed to delete image', err)
+    }
+  }
+
+  const updateImage = async (id, payload) => {
+    try {
+      const res = await fetch(`${API_URL}/images/${id}?site_name=${site_name}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('access_token')}`,
+        },
+        body: JSON.stringify(payload),
+      })
+      if (res.ok) setFiles((prev) => prev.map((f) => (f.id === id ? { ...f, ...payload } : f)))
+    } catch (err) {
+      console.error('Failed to update image', err)
+    }
+  }
+
+  const handleUploadClick = (categoryId) => {
+    if (uploadInputRef.current) {
+      uploadInputRef.current.dataset.categoryId = categoryId
+      uploadInputRef.current.click()
+    }
+  }
+
+  const handleInputChange = (e) => {
+    const categoryId = uploadInputRef.current?.dataset.categoryId
+    if (!categoryId) return
+    const list = Array.from(e.target.files || [])
+    uploadFiles(list, categoryId)
+    e.target.value = ''
+  }
+
+  return {
+    groups,
+    files,
+    selected,
+    setSelected,
+    used,
+    limit,
+    handleUploadClick,
+    uploadInputRef,
+    handleInputChange,
+    createCategory,
+    deleteImage,
+    updateImage,
+    refetch: fetchData,
+  }
 }

--- a/src/cloud/hooks/useTemplateGallery.js
+++ b/src/cloud/hooks/useTemplateGallery.js
@@ -17,8 +17,8 @@ export default function useTemplateGallery() {
           const parent = group.category_type === 'products' ? 'ТОВАРЫ' : 'СИСТЕМНЫЕ'
           if (!grouped[parent]) grouped[parent] = []
           grouped[parent].push({
+            id: group.id,
             title: group.description || group.name,
-            categories: [group.name],
           })
         }
 
@@ -28,10 +28,10 @@ export default function useTemplateGallery() {
         }))
         setGroups(mergedGroups)
 
-        const allFiles = data.flatMap(group =>
-          group.images.map(img => ({
+        const allFiles = data.flatMap((group) =>
+          group.images.map((img) => ({
             ...img,
-            category: group.name,
+            category: group.id,
             url: base + img.url,
           }))
         )


### PR DESCRIPTION
## Summary
- integrate site image API inside `useCloudStorage`
- allow adding categories and uploading images with selected category
- show edit/delete icons in image grid
- hook modal components to new API functions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684406a5387c83318d36ede89633af34