### PR TITLE
Fix library image preview

### DIFF
--- a/src/cloud/hooks/useTemplateGallery.js
+++ b/src/cloud/hooks/useTemplateGallery.js
@@ -9,7 +9,7 @@ export default function useTemplateGallery() {
       try {
         const res = await fetch(`${import.meta.env.VITE_API_URL}/cloud/library`)
         const data = await res.json()
-        const base = import.meta.env.VITE_LIBRARY_ASSETS_URL
+        const base = import.meta.env.VITE_LIBRARY_ASSETS_URL || ''
 
         const grouped = {}
 
@@ -32,7 +32,10 @@ export default function useTemplateGallery() {
           group.images.map((img) => ({
             ...img,
             category: group.id,
-            url: base + img.url,
+            url: base + (img.medium_url || img.url),
+            big_url: base + (img.big_url || img.url),
+            medium_url: base + (img.medium_url || img.url),
+            small_url: base + (img.small_url || img.url),
           }))
         )
         setFiles(allFiles)

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/TopBanner.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/TopBanner.jsx
@@ -16,7 +16,11 @@ export const TopBanner = ({ settings = {}, data = {}, commonSettings = {} }) => 
 
   const rawImagePath = data?.image_url || ''
   const baseUrl = import.meta.env.VITE_LIBRARY_ASSETS_URL || ''
-  const imageUrl = rawImagePath.startsWith('/sites') ? baseUrl + rawImagePath : pizzaImg
+  const imageUrl = rawImagePath
+    ? rawImagePath.startsWith('/')
+      ? baseUrl + rawImagePath
+      : rawImagePath
+    : pizzaImg
 
   const getGradient = () => {
     if (isCustom) {


### PR DESCRIPTION
## Summary
- preserve relative URLs when env var missing
- support library image paths in TopBanner

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848193e09448331843a29b709cf2882