### PR TITLE
Add logo field to header block

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Header.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Header.jsx
@@ -28,6 +28,10 @@ export const Header = ({ settings = {}, data = {}, commonSettings = {}, navigati
   const buttonHover = source?.button_hover_color || '#1565C0'
   const bgColor = source?.background_color || '#FFFFFF'
 
+  const rawLogoPath = data.logo_url || '/images/logo.webp'
+  const baseUrl = import.meta.env.VITE_LIBRARY_ASSETS_URL || ''
+  const logoUrl = rawLogoPath.startsWith('/') ? baseUrl + rawLogoPath : rawLogoPath
+
   const subtitle = data.subtitle || 'Описание'
   const city = data.city || 'Город'
   const deliveryTime = data.delivery_time || '33 мин'
@@ -45,7 +49,7 @@ export const Header = ({ settings = {}, data = {}, commonSettings = {}, navigati
       >
         <div className="flex flex-col items-start max-w-[100px]">
           <img
-            src="/images/logo.webp"
+            src={logoUrl}
             alt="Logo"
             className="w-[96px] h-auto object-contain"
           />

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/headerDataSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/headerDataSchema.js
@@ -1,5 +1,12 @@
 export const headerDataSchema = [
   {
+    key: 'logo_url',
+    label: 'Логотип',
+    type: 'image',
+    default: '/images/logo.webp',
+    editable: true,
+  },
+  {
     key: 'subtitle',
     label: 'Подзаголовок (сеть или описание)',
     type: 'text',


### PR DESCRIPTION
## Summary
- allow selecting logo from cloud for Header block
- display selected logo in preview before saving

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68483ba22bcc83319faf5b63390e2190