### PR TITLE
Implement QuickInfo editor

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
@@ -5,7 +5,6 @@ import { quickInfoDataSchema } from './quickInfoDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import QuickInfoItemsEditor from './ItemsEditor'
 import QuickInfoAppearance from './Appearance'
-import QuickInfoPreview from './QuickInfoPreview'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
@@ -14,7 +13,6 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
   const block_id = block?.real_id
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
-  const [showToast, setShowToast] = useState(false)
 
   useEffect(() => {
     setDataState(block?.data || {})
@@ -79,11 +77,6 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
 
   return (
     <div className="space-y-6 relative">
-      {showToast && (
-        <div className="absolute top-0 right-0 bg-green-100 text-green-800 px-3 py-1 rounded shadow text-sm transition-opacity duration-300">
-          ✅ Порядок сохранён
-        </div>
-      )}
       {(savedAppearance || savedData) && (
         <div className="text-green-600 text-sm font-medium">
           ✅ {savedAppearance ? 'Внешний вид' : 'Содержимое'} сохранено
@@ -95,12 +88,14 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
       </div>
 
       <QuickInfoItemsEditor
+        schema={quickInfoDataSchema}
+        data={dataState}
         settings={settingsState}
-        siteName={site_name}
-        siteData={siteData}
-        setData={setData}
-        onChange={onChange}
-        setShowToast={setShowToast}
+        onTextChange={handleTextFieldChange}
+        onSaveData={() => handleSaveData(dataState)}
+        showButton={showDataButton}
+        resetButton={resetData}
+        uiDefaults={uiDefaults}
       />
 
       <QuickInfoAppearance

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/ItemsEditor.jsx
@@ -1,7 +1,64 @@
-export default function QuickInfoItemsEditor() {
+import { useEffect, useState } from 'react'
+import { fieldTypes } from '@/components/fields/fieldTypes'
+
+export default function QuickInfoItemsEditor({
+  schema,
+  data,
+  settings = {},
+  onTextChange,
+  onSaveData,
+  showButton,
+  resetButton,
+  uiDefaults = {},
+}) {
+  const [internalVisible, setInternalVisible] = useState(false)
+
+  useEffect(() => {
+    if (resetButton) {
+      setInternalVisible(false)
+      return
+    }
+
+    if (showButton) {
+      setInternalVisible(true)
+    }
+  }, [showButton, resetButton])
+
+  const cols = settings?.grid_cols || 4
+  const limitedSchema = Array.isArray(schema) ? schema.slice(0, cols * 2) : []
+
+  const renderField = (field) => {
+    if (!field.editable) return null
+
+    const fieldKey = field.key
+    const textVal = data?.[fieldKey] ?? uiDefaults?.[fieldKey] ?? field.default ?? ''
+
+    const FieldComponent = fieldTypes[field.type] || fieldTypes.text
+    return (
+      <FieldComponent
+        {...field}
+        key={fieldKey}
+        value={textVal}
+        onChange={(val) => onTextChange(fieldKey, val)}
+        label={field.label}
+      />
+    )
+  }
+
   return (
-    <div className="text-gray-400 text-sm italic pl-1">
-      🔧 Настройка текста и иконок для блока "Быстрая информация" появится позже
+    <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
+      {limitedSchema.map(renderField)}
+
+      {internalVisible && (
+        <div>
+          <button
+            onClick={onSaveData}
+            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+          >
+            💾 Сохранить содержимое блока
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfo.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfo.jsx
@@ -45,26 +45,16 @@ export const QuickInfo = ({ settings = {}, data = {}, commonSettings = {} }) => 
     { title: 'Скидка за самовывоз', description: '−10%' },
   ]
 
-  const items = (() => {
-    if (
-      data?.title1 ||
-      data?.desc1 ||
-      data?.title2 ||
-      data?.desc2 ||
-      data?.title3 ||
-      data?.desc3 ||
-      data?.title4 ||
-      data?.desc4
-    ) {
-      return [
-        { title: data.title1, description: data.desc1 },
-        { title: data.title2, description: data.desc2 },
-        { title: data.title3, description: data.desc3 },
-        { title: data.title4, description: data.desc4 },
-      ]
-    }
-    return defaultItems
-  })()
+  const items = []
+  const count = Math.min(cols, defaultItems.length)
+  for (let i = 1; i <= count; i++) {
+    const titleKey = `title${i}`
+    const descKey = `desc${i}`
+    items.push({
+      title: data?.[titleKey] ?? defaultItems[i - 1].title,
+      description: data?.[descKey] ?? defaultItems[i - 1].description,
+    })
+  }
 
   const hexToRgba = (hex, alpha = 0.6) => {
     if (!hex || hex[0] !== '#' || (hex.length !== 7 && hex.length !== 4)) return hex


### PR DESCRIPTION
## Summary
- complete QuickInfo items editor
- make QuickInfo block render items depending on column count
- wire QuickInfo editor to save edited data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68491eb30bcc833180869cd8301f22de