### PR TITLE
Add card count and images to PromoCards block

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
@@ -83,6 +83,7 @@ export default function PromoEditor({ block, slug, onChange }) {
       <PromoItemsEditor
         schema={promoDataSchema}
         data={dataState}
+        settings={settingsState}
         onTextChange={handleDataChange}
         onSaveData={() => handleSaveData(dataState)}
         showButton={showDataButton}

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/ItemsEditor.jsx
@@ -4,6 +4,7 @@ import { fieldTypes } from '@/components/fields/fieldTypes'
 export default function PromoItemsEditor({
   schema,
   data,
+  settings = {},
   onTextChange,
   onSaveData,
   showButton,
@@ -22,6 +23,9 @@ export default function PromoItemsEditor({
       setInternalVisible(true)
     }
   }, [showButton, resetButton])
+
+  const count = settings?.card_count || 6
+  const limitedSchema = Array.isArray(schema) ? schema.slice(0, count * 3) : []
 
   const renderField = (field) => {
     if (!field.editable) return null
@@ -43,7 +47,7 @@ export default function PromoItemsEditor({
 
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
-      {schema.map(renderField)}
+      {limitedSchema.map(renderField)}
 
       {internalVisible && (
         <div>

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/PromoCards.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/PromoCards.jsx
@@ -49,12 +49,15 @@ export const PromoCards = ({ settings = {}, data = {}, commonSettings = {} }) =>
     { id: 6, title: 'Супер сырная', desc: 'Премиум рецепт', img_url: pizzaImg },
   ]
 
+  const cardCount = settings?.card_count || defaultCards.length
+
   const cards = Array.isArray(data.cards)
-    ? data.cards
-    : defaultCards.map((card, idx) => ({
+    ? data.cards.slice(0, cardCount)
+    : defaultCards.slice(0, cardCount).map((card, idx) => ({
         ...card,
         title: data[`card${idx + 1}_title`] || card.title,
         desc: data[`card${idx + 1}_desc`] || card.desc,
+        img_url: data[`card${idx + 1}_img`] || card.img_url,
       }))
 
   const scrollRef = useRef(null)

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/promoDataSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/promoDataSchema.js
@@ -14,6 +14,13 @@ export const promoDataSchema = [
     editable: true,
   },
   {
+    key: 'card1_img',
+    label: 'Изображение первой карточки',
+    type: 'image',
+    default: '/images/9.webp',
+    editable: true,
+  },
+  {
     key: 'card2_title',
     label: 'Заголовок второй карточки',
     type: 'text',
@@ -25,6 +32,13 @@ export const promoDataSchema = [
     label: 'Описание второй карточки',
     type: 'text',
     default: 'Только сегодня',
+    editable: true,
+  },
+  {
+    key: 'card2_img',
+    label: 'Изображение второй карточки',
+    type: 'image',
+    default: '/images/9.webp',
     editable: true,
   },
   {
@@ -42,6 +56,13 @@ export const promoDataSchema = [
     editable: true,
   },
   {
+    key: 'card3_img',
+    label: 'Изображение третьей карточки',
+    type: 'image',
+    default: '/images/9.webp',
+    editable: true,
+  },
+  {
     key: 'card4_title',
     label: 'Заголовок четвертой карточки',
     type: 'text',
@@ -53,6 +74,13 @@ export const promoDataSchema = [
     label: 'Описание четвертой карточки',
     type: 'text',
     default: 'Пицца с трюфелем',
+    editable: true,
+  },
+  {
+    key: 'card4_img',
+    label: 'Изображение четвертой карточки',
+    type: 'image',
+    default: '/images/9.webp',
     editable: true,
   },
   {
@@ -70,6 +98,13 @@ export const promoDataSchema = [
     editable: true,
   },
   {
+    key: 'card5_img',
+    label: 'Изображение пятой карточки',
+    type: 'image',
+    default: '/images/9.webp',
+    editable: true,
+  },
+  {
     key: 'card6_title',
     label: 'Заголовок шестой карточки',
     type: 'text',
@@ -81,6 +116,13 @@ export const promoDataSchema = [
     label: 'Описание шестой карточки',
     type: 'text',
     default: 'Премиум рецепт',
+    editable: true,
+  },
+  {
+    key: 'card6_img',
+    label: 'Изображение шестой карточки',
+    type: 'image',
+    default: '/images/9.webp',
     editable: true,
   },
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/promoSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/promoSchema.js
@@ -71,6 +71,14 @@ export const promoSchema = [
     visible_if: { custom_appearance: true }
   },
   {
+    key: 'card_count',
+    label: 'Количество карточек',
+    type: 'number',
+    default: 6,
+    editable: true,
+    visible_if: { custom_appearance: true }
+  },
+  {
     key: 'card_width',
     label: 'Ширина карточек (в px)',
     type: 'number',


### PR DESCRIPTION
## Summary
- allow configuring number of promo cards
- support per‑card images
- slice data schema by card count

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68496b6e53808331ab04b702382a3fcc