### PR TITLE
Implement dynamic promo and quick-info fields

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
@@ -83,6 +83,7 @@ export default function PromoEditor({ block, slug, onChange }) {
       <PromoItemsEditor
         schema={promoDataSchema}
         data={dataState}
+        settings={settingsState}
         onTextChange={handleDataChange}
         onSaveData={() => handleSaveData(dataState)}
         showButton={showDataButton}

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/ItemsEditor.jsx
@@ -4,6 +4,7 @@ import { fieldTypes } from '@/components/fields/fieldTypes'
 export default function PromoItemsEditor({
   schema,
   data,
+  settings = {},
   onTextChange,
   onSaveData,
   showButton,
@@ -22,6 +23,9 @@ export default function PromoItemsEditor({
       setInternalVisible(true)
     }
   }, [showButton, resetButton])
+
+  const count = settings?.cards_count || schema.length / 2
+  const limitedSchema = Array.isArray(schema) ? schema.slice(0, count * 2) : []
 
   const renderField = (field) => {
     if (!field.editable) return null
@@ -43,7 +47,7 @@ export default function PromoItemsEditor({
 
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
-      {schema.map(renderField)}
+      {limitedSchema.map(renderField)}
 
       {internalVisible && (
         <div>

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/PromoCards.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/PromoCards.jsx
@@ -38,6 +38,7 @@ export const PromoCards = ({ settings = {}, data = {}, commonSettings = {} }) =>
     block_padding_y = 24,
     card_width = 192,
     card_padding = 6,
+    cards_count = 6,
   } = source
 
   const defaultCards = [
@@ -49,13 +50,14 @@ export const PromoCards = ({ settings = {}, data = {}, commonSettings = {} }) =>
     { id: 6, title: 'Супер сырная', desc: 'Премиум рецепт', img_url: pizzaImg },
   ]
 
-  const cards = Array.isArray(data.cards)
+  const rawCards = Array.isArray(data.cards)
     ? data.cards
     : defaultCards.map((card, idx) => ({
         ...card,
         title: data[`card${idx + 1}_title`] || card.title,
         desc: data[`card${idx + 1}_desc`] || card.desc,
       }))
+  const cards = rawCards.slice(0, cards_count)
 
   const scrollRef = useRef(null)
   let isDown = false
@@ -107,6 +109,8 @@ export const PromoCards = ({ settings = {}, data = {}, commonSettings = {} }) =>
     high: 'shadow-xl',
   }[hover_shadow] || ''
 
+  const baseUrl = import.meta.env.VITE_LIBRARY_ASSETS_URL || ''
+
   return (
     <div
       className="w-full mt-4 mb-6 overflow-visible"
@@ -121,7 +125,13 @@ export const PromoCards = ({ settings = {}, data = {}, commonSettings = {} }) =>
         className="flex overflow-x-auto overflow-y-visible no-scrollbar px-2 cursor-grab select-none"
         style={{ gap: `${gap}px`, WebkitOverflowScrolling: 'touch' }}
       >
-        {cards.map((card) => (
+        {cards.map((card) => {
+          const imageUrl = card.img_url
+            ? card.img_url.startsWith('/')
+              ? baseUrl + card.img_url
+              : card.img_url
+            : pizzaImg
+          return (
           <div key={card.id} style={{ perspective: '1000px' }}>
             <div style={{ paddingTop: `${card_padding}px`, paddingBottom: `${card_padding}px` }}>
               <div
@@ -134,7 +144,7 @@ export const PromoCards = ({ settings = {}, data = {}, commonSettings = {} }) =>
               >
                 <div className="w-full h-[60%] flex items-center justify-center">
                   <img
-                    src={card.img_url || pizzaImg}
+                    src={imageUrl}
                     alt={card.title}
                     className="w-full h-full object-contain p-4"
                     draggable={false}
@@ -157,7 +167,7 @@ export const PromoCards = ({ settings = {}, data = {}, commonSettings = {} }) =>
               </div>
             </div>
           </div>
-        ))}
+        )})}
       </div>
     </div>
   )

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/promoSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/promoSchema.js
@@ -112,5 +112,13 @@ export const promoSchema = [
     default: 'medium',
     editable: true,
     visible_if: { custom_appearance: true }
+  },
+  {
+    key: 'cards_count',
+    label: 'Количество карточек',
+    type: 'number',
+    default: 6,
+    editable: true,
+    visible_if: { custom_appearance: true }
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
@@ -1,7 +1,10 @@
 import { useState, useEffect } from 'react'
 import { useSiteSettings } from '@/context/SiteSettingsContext'
 import { quickInfoSchema } from './quickInfoSchema'
-import { quickInfoDataSchema } from './quickInfoDataSchema'
+import {
+  quickInfoDataSchema,
+  createQuickInfoDataSchema,
+} from './quickInfoDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import QuickInfoItemsEditor from './ItemsEditor'
 import QuickInfoAppearance from './Appearance'
@@ -55,7 +58,7 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
     resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
-    schema: quickInfoDataSchema,
+    schema: createQuickInfoDataSchema(settingsState?.grid_cols || 4),
     data: dataState,
     block_id,
     slug,
@@ -88,7 +91,7 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
       </div>
 
       <QuickInfoItemsEditor
-        schema={quickInfoDataSchema}
+        schema={createQuickInfoDataSchema(settingsState?.grid_cols || 4)}
         data={dataState}
         settings={settingsState}
         onTextChange={handleTextFieldChange}

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/ItemsEditor.jsx
@@ -24,8 +24,7 @@ export default function QuickInfoItemsEditor({
     }
   }, [showButton, resetButton])
 
-  const cols = settings?.grid_cols || 4
-  const limitedSchema = Array.isArray(schema) ? schema.slice(0, cols * 2) : []
+  const limitedSchema = Array.isArray(schema) ? schema : []
 
   const renderField = (field) => {
     if (!field.editable) return null

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfo.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfo.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { defaultQuickInfoItems } from './quickInfoDataSchema'
 
 export const QuickInfo = ({ settings = {}, data = {}, commonSettings = {} }) => {
   const isCustom = settings?.custom_appearance === true
@@ -38,21 +39,19 @@ export const QuickInfo = ({ settings = {}, data = {}, commonSettings = {} }) => 
   const variant = source?.card_variant || 'flat'
   const showCards = source?.show_cards !== false
 
-  const defaultItems = [
-    { title: 'Мин. заказ на доставку', description: 'от 500 руб.' },
-    { title: 'Стоимость доставки', description: 'от 100 руб.' },
-    { title: 'Время доставки', description: 'до 59 мин.' },
-    { title: 'Скидка за самовывоз', description: '−10%' },
-  ]
+  const defaultItems = defaultQuickInfoItems
 
   const items = []
-  const count = Math.min(cols, defaultItems.length)
-  for (let i = 1; i <= count; i++) {
+  for (let i = 1; i <= cols; i++) {
     const titleKey = `title${i}`
     const descKey = `desc${i}`
+    const defaults = defaultItems[i - 1] || {
+      title: `Заголовок ${i}`,
+      desc: `Описание ${i}`,
+    }
     items.push({
-      title: data?.[titleKey] ?? defaultItems[i - 1].title,
-      description: data?.[descKey] ?? defaultItems[i - 1].description,
+      title: data?.[titleKey] ?? defaults.title,
+      description: data?.[descKey] ?? defaults.desc,
     })
   }
 

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/quickInfoDataSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/quickInfoDataSchema.js
@@ -1,10 +1,37 @@
-export const quickInfoDataSchema = [
-  { key: 'title1', label: 'Заголовок 1', type: 'text', default: 'Мин. заказ на доставку', editable: true },
-  { key: 'desc1', label: 'Описание 1', type: 'text', default: 'от 500 руб.', editable: true },
-  { key: 'title2', label: 'Заголовок 2', type: 'text', default: 'Стоимость доставки', editable: true },
-  { key: 'desc2', label: 'Описание 2', type: 'text', default: 'от 100 руб.', editable: true },
-  { key: 'title3', label: 'Заголовок 3', type: 'text', default: 'Время доставки', editable: true },
-  { key: 'desc3', label: 'Описание 3', type: 'text', default: 'до 59 мин.', editable: true },
-  { key: 'title4', label: 'Заголовок 4', type: 'text', default: 'Скидка за самовывоз', editable: true },
-  { key: 'desc4', label: 'Описание 4', type: 'text', default: '−10%', editable: true },
+export const defaultQuickInfoItems = [
+  { title: 'Мин. заказ на доставку', desc: 'от 500 руб.' },
+  { title: 'Стоимость доставки', desc: 'от 100 руб.' },
+  { title: 'Время доставки', desc: 'до 59 мин.' },
+  { title: 'Скидка за самовывоз', desc: '−10%' },
 ]
+
+export const createQuickInfoDataSchema = (count = 4) => {
+  const schema = []
+  for (let i = 1; i <= count; i++) {
+    const base = defaultQuickInfoItems[i - 1] || {
+      title: `Заголовок ${i}`,
+      desc: `Описание ${i}`,
+    }
+
+    schema.push(
+      {
+        key: `title${i}`,
+        label: `Заголовок ${i}`,
+        type: 'text',
+        default: base.title,
+        editable: true,
+      },
+      {
+        key: `desc${i}`,
+        label: `Описание ${i}`,
+        type: 'text',
+        default: base.desc,
+        editable: true,
+      },
+    )
+  }
+
+  return schema
+}
+
+export const quickInfoDataSchema = createQuickInfoDataSchema(4)


### PR DESCRIPTION
## Summary
- adjust promo cards editor to limit text fields by card count
- extend promo schema with `cards_count`
- generate quick info fields dynamically based on `grid_cols`
- show new quick info columns in preview
- handle relative image URLs in promo cards preview

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68496ea0770083318bd866a59938b450