### PR TITLE
Fix PromoCards items count and preview overflow

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/ItemsEditor.jsx
@@ -24,8 +24,12 @@ export default function PromoItemsEditor({
     }
   }, [showButton, resetButton])
 
-  const count = settings?.cards_count || schema.length / 2
-  const limitedSchema = Array.isArray(schema) ? schema.slice(0, count * 2) : []
+  const fieldsPerCard = 3
+  const defaultCards = schema.length / fieldsPerCard
+  const count = settings?.cards_count || defaultCards
+  const limitedSchema = Array.isArray(schema)
+    ? schema.slice(0, count * fieldsPerCard)
+    : []
 
   const renderField = (field) => {
     if (!field.editable) return null

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
@@ -2,7 +2,7 @@ import BlockDetails from '@/pages/Sites/SiteSettings/PagesTab/BlocksEditor/previ
 
 export default function BlockEditorPanel({ selectedBlock, selectedData, onSave }) {
   return (
-    <div className="flex-1 border rounded p-4 bg-white shadow-sm min-h-[200px]">
+    <div className="flex-1 border rounded p-4 bg-white shadow-sm min-h-[200px] overflow-x-auto">
       <BlockDetails
         block={selectedBlock}
         data={{ ...selectedData, block_id: selectedBlock?.real_id }}


### PR DESCRIPTION
## Summary
- correct card field calculation in PromoCards item editor
- prevent preview panel from expanding horizontally when many cards are shown

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684978f4891483318f3fc11cfce27587