### PR TITLE
Implement PopularItems editor

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useSiteSettings } from '@/context/SiteSettingsContext'
 import { productsSchema } from './productsSchema'
-import { productsDataSchema } from './productsDataSchema'
+import { createProductsDataSchema } from './productsDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import ProductsItemsEditor from './ItemsEditor'
 import ProductsAppearance from './Appearance'
@@ -12,7 +12,6 @@ import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 export default function ProductsEditor({ block, slug, onChange }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
-  const [showToast, setShowToast] = useState(false)
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
 
@@ -52,7 +51,7 @@ export default function ProductsEditor({ block, slug, onChange }) {
     resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
-    schema: productsDataSchema,
+    schema: createProductsDataSchema(settingsState?.cards_count || 3),
     data: dataState,
     block_id,
     slug,
@@ -69,11 +68,6 @@ export default function ProductsEditor({ block, slug, onChange }) {
 
   return (
     <div className="space-y-6 relative">
-      {showToast && (
-        <div className="absolute top-0 right-0 bg-green-100 text-green-800 px-3 py-1 rounded shadow text-sm transition-opacity duration-300">
-          ✅ Порядок сохранён
-        </div>
-      )}
       {(savedAppearance || savedData) && (
         <div className="text-green-600 text-sm font-medium">
           ✅ {savedAppearance ? 'Внешний вид' : 'Содержимое'} сохранено
@@ -85,16 +79,14 @@ export default function ProductsEditor({ block, slug, onChange }) {
       </div>
 
       <ProductsItemsEditor
-        settings={settingsState}
+        schema={createProductsDataSchema(settingsState?.cards_count || 3)}
         data={dataState}
-        siteName={site_name}
-        siteData={siteData}
-        setData={setData}
-        onChange={handleDataChange}
-        setShowToast={setShowToast}
+        settings={settingsState}
+        onTextChange={handleDataChange}
         onSaveData={() => handleSaveData(dataState)}
         showButton={showDataButton}
         resetButton={resetData}
+        uiDefaults={uiDefaults}
       />
 
       <ProductsAppearance

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/ItemsEditor.jsx
@@ -1,7 +1,66 @@
-export default function ProductsItemsEditor() {
+import { useEffect, useState } from 'react'
+import { fieldTypes } from '@/components/fields/fieldTypes'
+
+export default function ProductsItemsEditor({
+  schema,
+  data,
+  settings = {},
+  onTextChange,
+  onSaveData,
+  showButton,
+  resetButton,
+  uiDefaults = {},
+}) {
+  const [internalVisible, setInternalVisible] = useState(false)
+
+  useEffect(() => {
+    if (resetButton) {
+      setInternalVisible(false)
+      return
+    }
+
+    if (showButton) {
+      setInternalVisible(true)
+    }
+  }, [showButton, resetButton])
+
+  const count = settings?.cards_count || (schema.length - 1) / 3
+  const limitedSchema = Array.isArray(schema)
+    ? [schema[0], ...schema.slice(1, 1 + count * 3)]
+    : []
+
+  const renderField = (field) => {
+    if (!field.editable) return null
+
+    const fieldKey = field.key
+    const textVal = data?.[fieldKey] ?? uiDefaults?.[fieldKey] ?? field.default ?? ''
+
+    const FieldComponent = fieldTypes[field.type] || fieldTypes.text
+    return (
+      <FieldComponent
+        {...field}
+        key={fieldKey}
+        value={textVal}
+        onChange={(val) => onTextChange(fieldKey, val)}
+        label={field.label}
+      />
+    )
+  }
+
   return (
-    <div className="text-gray-400 text-sm italic pl-1">
-      🔧 Редактирование списка популярных товаров будет доступно позже
+    <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
+      {limitedSchema.map(renderField)}
+
+      {internalVisible && (
+        <div>
+          <button
+            onClick={onSaveData}
+            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+          >
+            💾 Сохранить содержимое блока
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItems.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItems.jsx
@@ -48,12 +48,27 @@ export const PopularItems = ({ settings = {}, data = {}, commonSettings = {} }) 
   const imageSize = imageSizeMap[source?.image_size] || 'w-24 h-24'
 
   const defaultItems = [
-    { id: 1, name: 'Пепперони фреш', price: 'от 409 ₽' },
-    { id: 2, name: '3 пиццы 30 см', price: '1 449 ₽' },
-    { id: 3, name: '2 соуса', price: '75 ₽' },
+    { id: 1, name: 'Пепперони фреш', price: 'от 409 ₽', img_url: pizzaImg },
+    { id: 2, name: '3 пиццы 30 см', price: '1 449 ₽', img_url: pizzaImg },
+    { id: 3, name: '2 соуса', price: '75 ₽', img_url: pizzaImg },
+    { id: 4, name: 'Товар 4', price: '', img_url: pizzaImg },
+    { id: 5, name: 'Товар 5', price: '', img_url: pizzaImg },
+    { id: 6, name: 'Товар 6', price: '', img_url: pizzaImg },
   ]
 
-  const items = data.items?.length ? data.items : defaultItems
+  const rawItems = Array.isArray(data.items)
+    ? data.items
+    : defaultItems.map((item, idx) => ({
+        ...item,
+        name: data[`item${idx + 1}_name`] || item.name,
+        price: data[`item${idx + 1}_price`] || item.price,
+        img_url: data[`item${idx + 1}_img`] || item.img_url,
+      }))
+
+  const cards_count = settings?.cards_count || defaultItems.length
+  const items = rawItems.slice(0, cards_count)
+
+  const baseUrl = import.meta.env.VITE_LIBRARY_ASSETS_URL || ''
 
   const cssVars = {
     '--padding-top': `${paddingTop}px`,
@@ -90,7 +105,7 @@ export const PopularItems = ({ settings = {}, data = {}, commonSettings = {} }) 
               }}
             />
             <img
-              src={pizzaImg}
+              src={item.img_url ? (item.img_url.startsWith('/') ? baseUrl + item.img_url : item.img_url) : pizzaImg}
               alt={item.name}
               className={`${imageSize} object-cover`}
             />

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/productsDataSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/productsDataSchema.js
@@ -1,20 +1,56 @@
-export const productsDataSchema = [
-  {
-    key: 'title',
-    label: 'Заголовок блока',
-    type: 'text',
-    default: 'Часто заказывают',
-    editable: true,
-  },
-  {
-    key: 'items',
-    label: 'Популярные товары',
-    type: 'array',
-    default: [
-      { id: 1, name: 'Пепперони фреш', price: 'от 409 ₽' },
-      { id: 2, name: '3 пиццы 30 см', price: '1 449 ₽' },
-      { id: 3, name: '2 соуса', price: '75 ₽' },
-    ],
-    editable: true,
-  },
+export const defaultPopularItems = [
+  { name: 'Пепперони фреш', price: 'от 409 ₽', img: '/images/8.webp' },
+  { name: '3 пиццы 30 см', price: '1 449 ₽', img: '/images/8.webp' },
+  { name: '2 соуса', price: '75 ₽', img: '/images/8.webp' },
+  { name: 'Товар 4', price: '', img: '/images/8.webp' },
+  { name: 'Товар 5', price: '', img: '/images/8.webp' },
+  { name: 'Товар 6', price: '', img: '/images/8.webp' },
 ]
+
+export const createProductsDataSchema = (count = 3) => {
+  const schema = [
+    {
+      key: 'title',
+      label: 'Заголовок блока',
+      type: 'text',
+      default: 'Часто заказывают',
+      editable: true,
+    },
+  ]
+
+  for (let i = 1; i <= count; i++) {
+    const base = defaultPopularItems[i - 1] || {
+      name: `Товар ${i}`,
+      price: '',
+      img: '/images/8.webp',
+    }
+
+    schema.push(
+      {
+        key: `item${i}_name`,
+        label: `Название ${i}-го товара`,
+        type: 'text',
+        default: base.name,
+        editable: true,
+      },
+      {
+        key: `item${i}_price`,
+        label: `Цена ${i}-го товара`,
+        type: 'text',
+        default: base.price,
+        editable: true,
+      },
+      {
+        key: `item${i}_img`,
+        label: `Изображение ${i}-го товара`,
+        type: 'image',
+        default: base.img,
+        editable: true,
+      },
+    )
+  }
+
+  return schema
+}
+
+export const productsDataSchema = createProductsDataSchema(6)

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/productsSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/productsSchema.js
@@ -102,5 +102,13 @@ export const productsSchema = [
     default: 40,
     editable: true,
     visible_if: { custom_appearance: true }
+  },
+  {
+    key: 'cards_count',
+    label: 'Количество карточек',
+    type: 'number',
+    default: 3,
+    editable: true,
+    visible_if: { custom_appearance: true }
   }
 ]


### PR DESCRIPTION
## Summary
- expand PopularItems to support editable items similar to PromoCards
- add dynamic schema creator with image fields
- allow configuring number of cards
- update editor and block rendering logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68498026ae788331a659e15f4912dd9c