### PR TITLE
Fix PopularItems preview

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItemsPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItemsPreview.jsx
@@ -4,7 +4,7 @@ import { PreviewWrapper } from '@preview/PreviewWrapper'
 import { PopularItems } from './PopularItems'
 import { applyCssVariablesFromUiSchema } from '@preview/utils/applyCssVariables'
 
-export default function PopularItemsPreview({ settings = {}, commonSettings = {} }) {
+export default function PopularItemsPreview({ settings = {}, data = {}, commonSettings = {} }) {
   const { data: globalSiteData } = useSiteSettings()
   const [styleVars, setStyleVars] = useState({})
 
@@ -37,7 +37,7 @@ export default function PopularItemsPreview({ settings = {}, commonSettings = {}
     <PreviewWrapper>
       <div style={styleVars}>
         <div className="max-w-full mx-auto text-[13px] leading-tight">
-          <PopularItems settings={settings} commonSettings={commonSettings} />
+          <PopularItems settings={settings} data={data} commonSettings={commonSettings} />
         </div>
       </div>
     </PreviewWrapper>

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -72,7 +72,7 @@ export default function BlockDetails({ block, data, onSave }) {
         siteData?.navigation?.filter(n => n.block_id === block.real_id && n.visible) || []
     }
 
-    if (['banner', 'info', 'promo'].includes(block.type)) {
+    if (['banner', 'info', 'promo', 'products'].includes(block.type)) {
       previewProps.data = form.data || form
       previewProps.commonSettings = siteData?.common || {}
     }


### PR DESCRIPTION
## Summary
- pass data prop to PopularItemsPreview
- feed data/commonSettings to PopularItems preview in BlockDetails

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849832202388331a8f308f64e8a6a36