### PR TITLE
Add review count setting and live preview

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useSiteSettings } from '@/context/SiteSettingsContext'
 import { reviewsSchema } from './reviewsSchema'
-import { reviewsDataSchema } from './reviewsDataSchema'
+import { createReviewsDataSchema } from './reviewsDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import ReviewsItemsEditor from './ItemsEditor'
 import ReviewsAppearance from './Appearance'
@@ -50,7 +50,7 @@ export default function ReviewsEditor({ block, slug, onChange }) {
     resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
-    schema: reviewsDataSchema,
+    schema: createReviewsDataSchema(settingsState?.reviews_count || 4),
     data: dataState,
     block_id,
     slug,
@@ -80,8 +80,9 @@ export default function ReviewsEditor({ block, slug, onChange }) {
       </div>
 
       <ReviewsItemsEditor
-        schema={reviewsDataSchema}
+        schema={createReviewsDataSchema(settingsState?.reviews_count || 4)}
         data={dataState}
+        settings={settingsState}
         onTextChange={handleDataChange}
         onSaveData={() => handleSaveData(dataState)}
         showButton={showDataButton}

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/ItemsEditor.jsx
@@ -4,6 +4,7 @@ import { fieldTypes } from '@/components/fields/fieldTypes'
 export default function ReviewsItemsEditor({
   schema,
   data,
+  settings = {},
   onTextChange,
   onSaveData,
   showButton,
@@ -22,6 +23,13 @@ export default function ReviewsItemsEditor({
       setInternalVisible(true)
     }
   }, [showButton, resetButton])
+
+  const fieldsPerReview = 4
+  const defaultReviews = schema.length / fieldsPerReview
+  const count = settings?.reviews_count || defaultReviews
+  const limitedSchema = Array.isArray(schema)
+    ? schema.slice(0, count * fieldsPerReview)
+    : []
 
   const renderField = (field) => {
     if (!field.editable) return null
@@ -43,7 +51,7 @@ export default function ReviewsItemsEditor({
 
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
-      {schema.map(renderField)}
+      {limitedSchema.map(renderField)}
 
       {internalVisible && (
         <div>

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Reviews.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Reviews.jsx
@@ -20,6 +20,7 @@ export const Reviews = ({ settings = {}, data = {}, commonSettings = {} }) => {
         avatar_size: 'medium',
         card_shadow: 'low',
         transition_effect: 'slide',
+        reviews_count: defaultReviews.length,
       }
 
   const sectionBg = source?.section_bg_color || '#F9FAFB'
@@ -50,7 +51,8 @@ export const Reviews = ({ settings = {}, data = {}, commonSettings = {} }) => {
         img_url: data[`review${idx + 1}_img`] ?? rev.img_url,
       }))
 
-  const reviews = rawReviews
+  const reviews_count = source?.reviews_count || rawReviews.length
+  const reviews = rawReviews.slice(0, reviews_count)
 
   const sectionRef = useRef(null)
   const scrollRef = useRef(null)

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/reviewsSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/reviewsSchema.js
@@ -104,5 +104,13 @@ export const reviewsSchema = [
     default: 'slide',
     editable: true,
     visible_if: { custom_appearance: true }
+  },
+  {
+    key: 'reviews_count',
+    label: 'Количество отзывов',
+    type: 'number',
+    default: 4,
+    editable: true,
+    visible_if: { custom_appearance: true }
   }
 ]


### PR DESCRIPTION
## Summary
- allow configuring number of reviews
- render only selected number of reviews
- update reviews preview as fields change

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684986a2a8e083318303a0b3daa7ee74