### PR TITLE
Fix PopularItems preview item count

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItems.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItems.jsx
@@ -65,8 +65,9 @@ export const PopularItems = ({ settings = {}, data = {}, commonSettings = {} }) 
         img_url: data[`item${idx + 1}_img`] || item.img_url,
       }))
 
-  const cards_count = settings?.cards_count || defaultItems.length
-  const items = rawItems.slice(0, cards_count)
+  const parsedCount = parseInt(settings?.cards_count, 10)
+  const cardsCount = Number.isFinite(parsedCount) && parsedCount > 0 ? parsedCount : defaultItems.length
+  const items = rawItems.slice(0, cardsCount)
 
   const baseUrl = import.meta.env.VITE_LIBRARY_ASSETS_URL || ''
 


### PR DESCRIPTION
## Summary
- ensure PopularItems preview respects the `cards_count` setting by validating
  and using the parsed value

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684987260b6883319e9ae868ac4f2f67