### PR TITLE
Implement dynamic footer editing and preview

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
@@ -1,13 +1,24 @@
+import { useState, useEffect } from 'react'
 import { useSiteSettings } from '@/context/SiteSettingsContext'
 import { footerSchema } from './footerSchema'
+import { footerDataSchema } from './footerDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import FooterItemsEditor from './ItemsEditor'
 import FooterAppearance from './Appearance'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
+import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
 export default function FooterEditor({ block, data, onChange, slug }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
+
+  const [dataState, setDataState] = useState(block?.data || {})
+  const [settingsState, setSettingsState] = useState(block?.settings || {})
+
+  useEffect(() => {
+    setDataState(block?.data || {})
+    setSettingsState(block?.settings || {})
+  }, [block])
 
   const {
     handleFieldChange,
@@ -18,34 +29,72 @@ export default function FooterEditor({ block, data, onChange, slug }) {
     uiDefaults,
   } = useBlockAppearance({
     schema: footerSchema,
-    data,
+    data: settingsState,
     block_id,
     slug,
     siteData,
     site_name,
     setData,
-    onChange,
+    onChange: update => {
+      setSettingsState(update)
+      onChange(prev => ({
+        ...prev,
+        settings: typeof update === 'function' ? update(prev.settings || {}) : update,
+      }))
+    },
+  })
+
+  const {
+    handleFieldChange: handleDataChange,
+    handleSaveData,
+    showSavedToast: savedData,
+    resetButton: resetData,
+    showSaveButton: showDataButton,
+  } = useBlockData({
+    schema: footerDataSchema,
+    data: dataState,
+    block_id,
+    slug,
+    site_name,
+    setData,
+    onChange: update => {
+      setDataState(update)
+      onChange(prev => ({
+        ...prev,
+        data: typeof update === 'function' ? update(prev.data || {}) : update,
+      }))
+    },
   })
 
   return (
     <div className="space-y-6 relative">
-      {showSavedToast && (
-        <div className="text-green-600 text-sm font-medium">✅ Внешний вид сохранён</div>
+      {(showSavedToast || savedData) && (
+        <div className="text-green-600 text-sm font-medium">
+          ✅ {showSavedToast ? 'Внешний вид' : 'Содержимое'} сохранено
+        </div>
       )}
 
       <div className="text-sm text-gray-500 italic pl-1">
         ⚙️ Настройка подвала: цвета фона, текста и линии
       </div>
 
-      <FooterItemsEditor />
+      <FooterItemsEditor
+        schema={footerDataSchema}
+        data={dataState}
+        onTextChange={handleDataChange}
+        onSaveData={() => handleSaveData(dataState)}
+        showButton={showDataButton}
+        resetButton={resetData}
+        uiDefaults={uiDefaults}
+      />
 
       <FooterAppearance
         schema={footerSchema}
-        settings={data}
+        settings={settingsState}
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
-        onSaveAppearance={handleSaveAppearance}
-        showButton={showSaveButton || data?.custom_appearance === false}
+        onSaveAppearance={() => handleSaveAppearance(settingsState)}
+        showButton={showSaveButton || settingsState?.custom_appearance === false}
         resetButton={resetButton}
         uiDefaults={uiDefaults}
       />

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Footer.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Footer.jsx
@@ -1,0 +1,152 @@
+import { Facebook, Instagram, Youtube, Twitter, Phone, Mail } from 'lucide-react'
+import { SiVk, SiTelegram } from 'react-icons/si'
+
+export const Footer = ({ settings = {}, commonSettings = {}, data = {} }) => {
+  const isCustom = settings?.custom_appearance === true
+
+  const source = isCustom
+    ? settings
+    : {
+        background_color: commonSettings.background?.muted,
+        text_color: commonSettings.text?.primary,
+        border_color: commonSettings.background?.surface,
+        font_family: commonSettings.typography?.font_family,
+        font_size_base: 14,
+        transition_duration: `${commonSettings.transition?.duration || 0.3}s`,
+        icon_color: commonSettings.icon?.default,
+        icon_color_hover: commonSettings.icon?.hover,
+        alignment: 'spread',
+        section_spacing_top: 48,
+        section_spacing_bottom: 24,
+        show_sections: {
+          about: true,
+          contacts: true,
+          socials: true,
+        },
+        show_social_icons: {
+          facebook: true,
+          instagram: true,
+          vk: true,
+          youtube: true,
+          telegram: true,
+          twitter: true,
+        },
+        show_payment_icons: false,
+      }
+
+  const {
+    background_color = '#FFFFFF',
+    text_color = '#212121',
+    border_color = 'rgba(0,0,0,0.1)',
+    font_family = 'inherit',
+    font_size_base = 14,
+    transition_duration = '0.3s',
+    icon_color = '#6B7280',
+    icon_color_hover = '#374151',
+    alignment = 'spread',
+    section_spacing_top = 48,
+    section_spacing_bottom = 24,
+    show_sections = { about: true, contacts: true, socials: true },
+    show_social_icons = {
+      facebook: true,
+      instagram: true,
+      vk: true,
+      youtube: true,
+      telegram: true,
+      twitter: true,
+    },
+  } = source
+
+  const alignmentClass = {
+    left: 'items-start text-left',
+    center: 'items-center text-center',
+    spread: 'md:items-start md:text-left text-center md:text-left',
+  }[alignment] || 'md:items-start text-left'
+
+  const socialIcons = [
+    { key: 'facebook', Icon: Facebook, href: data.facebook_link || '#' },
+    { key: 'instagram', Icon: Instagram, href: data.instagram_link || '#' },
+    { key: 'vk', Icon: SiVk, href: data.vk_link || '#' },
+    { key: 'youtube', Icon: Youtube, href: data.youtube_link || '#' },
+    { key: 'telegram', Icon: SiTelegram, href: data.telegram_link || '#' },
+    { key: 'twitter', Icon: Twitter, href: data.twitter_link || '#' },
+  ]
+
+  return (
+    <footer
+      className="w-full"
+      style={{
+        backgroundColor: background_color,
+        color: text_color,
+        fontFamily: font_family,
+        fontSize: `${font_size_base}px`,
+        transition: `all ${transition_duration}`,
+        paddingTop: `${section_spacing_top}px`,
+        paddingBottom: `${section_spacing_bottom}px`,
+      }}
+    >
+      <div className={`w-full px-4 sm:px-6 lg:px-12`}>
+        <div className={`max-w-screen-xl mx-auto grid gap-8 md:grid-cols-3 ${alignmentClass}`}>
+          {show_sections.about && (
+            <div>
+              <h4 className="text-base font-semibold mb-2">О компании</h4>
+              <p style={{ opacity: 0.8 }}>
+                Мы доставляем горячую пиццу с любовью. Работаем с 10:00 до 23:00 каждый день.
+              </p>
+            </div>
+          )}
+
+          {show_sections.contacts && (
+            <div>
+              <h4 className="text-base font-semibold mb-2">Контакты</h4>
+              <ul style={{ opacity: 0.8 }} className="space-y-1">
+                <li className="flex items-center justify-center md:justify-start gap-2">
+                  <Phone className="w-4 h-4" style={{ color: icon_color }} /> +84 123 456 789
+                </li>
+                <li className="flex items-center justify-center md:justify-start gap-2">
+                  <Mail className="w-4 h-4" style={{ color: icon_color }} /> support@pizzadelivery.vn
+                </li>
+              </ul>
+            </div>
+          )}
+
+          {show_sections.socials && (
+            <div>
+              <h4 className="text-base font-semibold mb-2">Мы в соцсетях</h4>
+              <div className="flex justify-center md:justify-start gap-4" style={{ opacity: 0.8 }}>
+                {socialIcons
+                  .filter(({ key }) => show_social_icons?.[key])
+                  .map(({ key, Icon, href }) => (
+                    <a
+                      key={key}
+                      href={href}
+                      className="hover:opacity-100 transition-opacity"
+                      style={{ color: icon_color }}
+                      onMouseEnter={(e) => (e.currentTarget.style.color = icon_color_hover)}
+                      onMouseLeave={(e) => (e.currentTarget.style.color = icon_color)}
+                    >
+                      <Icon className="w-5 h-5" />
+                    </a>
+                  ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div
+        className="text-center text-xs py-4 border-t mt-8"
+        style={{
+          opacity: 0.7,
+          borderColor: border_color,
+          borderTopWidth: 1,
+          borderStyle: 'solid',
+        }}
+      >
+        © {new Date().getFullYear()} PizzaDelivery. Все права защищены.
+      </div>
+    </footer>
+  )
+}
+
+export default Footer

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/FooterPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/FooterPreview.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { PreviewWrapper } from '@preview/PreviewWrapper'
+import Footer from './Footer'
+import { applyCssVariablesFromUiSchema } from '@preview/utils/applyCssVariables'
+import { useSiteSettings } from '@/context/SiteSettingsContext'
+
+export default function FooterPreview({ settings = {}, data = {}, commonSettings = {} }) {
+  const { data: globalSiteData } = useSiteSettings()
+  const [styleVars, setStyleVars] = useState({})
+
+  useEffect(() => {
+    if (!globalSiteData?.ui_schema) return
+
+    if (settings?.custom_appearance) {
+      const vars = {}
+      Object.entries(settings).forEach(([key, val]) => {
+        if (key.includes('color') || key.startsWith('bg_')) {
+          vars[`--${key.replace(/_/g, '-')}`] = val
+        }
+      })
+
+      const varsJson = JSON.stringify(vars)
+      const styleVarsJson = JSON.stringify(styleVars)
+
+      if (varsJson !== styleVarsJson) {
+        setStyleVars(vars)
+      }
+    } else {
+      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+      if (Object.keys(styleVars).length > 0) {
+        setStyleVars({})
+      }
+    }
+  }, [settings, globalSiteData?.ui_schema])
+
+  return (
+    <PreviewWrapper>
+      <div style={styleVars}>
+        <Footer settings={settings} data={data} commonSettings={commonSettings} />
+      </div>
+    </PreviewWrapper>
+  )
+}

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/ItemsEditor.jsx
@@ -1,7 +1,60 @@
-export default function FooterItemsEditor() {
+import { useEffect, useState } from 'react'
+import { fieldTypes } from '@/components/fields/fieldTypes'
+
+export default function FooterItemsEditor({
+  schema = [],
+  data = {},
+  onTextChange,
+  onSaveData,
+  showButton,
+  resetButton,
+  uiDefaults = {},
+}) {
+  const [internalVisible, setInternalVisible] = useState(false)
+
+  useEffect(() => {
+    if (resetButton) {
+      setInternalVisible(false)
+      return
+    }
+
+    if (showButton) {
+      setInternalVisible(true)
+    }
+  }, [showButton, resetButton])
+
+  const renderField = field => {
+    if (!field.editable) return null
+
+    const fieldKey = field.key
+    const textVal = data?.[fieldKey] ?? uiDefaults?.[fieldKey] ?? field.default ?? ''
+    const FieldComponent = fieldTypes[field.type] || fieldTypes.text
+
+    return (
+      <FieldComponent
+        {...field}
+        key={fieldKey}
+        value={textVal}
+        onChange={val => onTextChange(fieldKey, val)}
+        label={field.label}
+      />
+    )
+  }
+
   return (
-    <div className="text-gray-400 text-sm italic pl-1">
-      🔧 Редактирование текста и ссылок подвала будет доступно позже
+    <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
+      {schema.map(renderField)}
+
+      {internalVisible && (
+        <div>
+          <button
+            onClick={onSaveData}
+            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+          >
+            💾 Сохранить содержимое блока
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/footerDataSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/footerDataSchema.js
@@ -1,0 +1,8 @@
+export const footerDataSchema = [
+  { key: 'facebook_link', label: 'Ссылка Facebook', type: 'text', default: '#', editable: true },
+  { key: 'instagram_link', label: 'Ссылка Instagram', type: 'text', default: '#', editable: true },
+  { key: 'vk_link', label: 'Ссылка VK', type: 'text', default: '#', editable: true },
+  { key: 'youtube_link', label: 'Ссылка YouTube', type: 'text', default: '#', editable: true },
+  { key: 'telegram_link', label: 'Ссылка Telegram', type: 'text', default: '#', editable: true },
+  { key: 'twitter_link', label: 'Ссылка Twitter', type: 'text', default: '#', editable: true },
+]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/footerSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/footerSchema.js
@@ -97,6 +97,29 @@ export const footerSchema = [
     visible_if: { custom_appearance: true }
   },
   {
+    key: 'show_social_icons',
+    label: 'Отображать соцсети',
+    type: 'multicheckbox',
+    options: [
+      { key: 'facebook', label: 'Facebook' },
+      { key: 'instagram', label: 'Instagram' },
+      { key: 'vk', label: 'VK' },
+      { key: 'youtube', label: 'YouTube' },
+      { key: 'telegram', label: 'Telegram' },
+      { key: 'twitter', label: 'Twitter' },
+    ],
+    default: {
+      facebook: true,
+      instagram: true,
+      vk: true,
+      youtube: true,
+      telegram: true,
+      twitter: true,
+    },
+    editable: true,
+    visible_if: { custom_appearance: true },
+  },
+  {
     key: 'show_payment_icons',
     label: 'Показывать иконки оплат',
     type: 'boolean',

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -72,7 +72,7 @@ export default function BlockDetails({ block, data, onSave }) {
         siteData?.navigation?.filter(n => n.block_id === block.real_id && n.visible) || []
     }
 
-    if (['banner', 'info', 'promo', 'products', 'reviews', 'delivery'].includes(block.type)) {
+    if (['banner', 'info', 'promo', 'products', 'reviews', 'delivery', 'footer'].includes(block.type)) {
       previewProps.data = form.data || form
       previewProps.commonSettings = siteData?.common || {}
     }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/blockMap.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/blockMap.js
@@ -6,6 +6,7 @@ import PromoCardsPreview from '@blocks/forms/PromoCards/PromoCardsPreview'
 import PopularItemsPreview from '@blocks/forms/PopularItems/PopularItemsPreview'
 import ReviewsPreview from '@blocks/forms/Reviews/ReviewsPreview'
 import DeliveryPreview from '@blocks/forms/Delivery/DeliveryPreview'
+import FooterPreview from '@blocks/forms/Footer/FooterPreview'
 
 export const previewBlocks = {
   navigation: NavigationPreview,
@@ -16,6 +17,7 @@ export const previewBlocks = {
   products: PopularItemsPreview,
   reviews: ReviewsPreview,
   delivery: DeliveryPreview,
+  footer: FooterPreview,
 }
 
 // Добавляй сюда остальные блоки по мере добавления


### PR DESCRIPTION
## Summary
- add footer component and dynamic preview
- allow editing social links via new footer data schema
- enable toggling of social icons and preview support
- integrate footer with BlockDetails preview logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a5dafd0948331aafb713536e4edf1