### PR TITLE
Add AboutCompany editing and preview

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/AboutCompany.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/AboutCompany.jsx
@@ -1,0 +1,58 @@
+import React from 'react'
+
+export const AboutCompany = ({ settings = {}, data = {}, commonSettings = {} }) => {
+  const isCustom = settings?.custom_appearance === true
+
+  const source = isCustom
+    ? settings
+    : {
+        background_color: commonSettings.background?.base,
+        text_color: commonSettings.text?.primary,
+        subtle_text_color: commonSettings.text?.secondary,
+        padding_top: 48,
+        padding_bottom: 48,
+        title_font_size: 24,
+        desc_font_size: 16,
+        max_width: 768,
+        text_align: 'center',
+      }
+
+  const {
+    background_color = '#FFFFFF',
+    text_color = '#212121',
+    subtle_text_color = '#6B7280',
+    padding_top = 48,
+    padding_bottom = 48,
+    title_font_size = 24,
+    desc_font_size = 16,
+    max_width = 768,
+    text_align = 'center',
+  } = source
+
+  const title = data.title || 'О компании'
+  const text = data.text || 'Мы доставляем горячую пиццу с любовью. Работаем с 10:00 до 23:00 каждый день.'
+
+  return (
+    <div
+      className="w-full px-4"
+      style={{
+        backgroundColor: background_color,
+        paddingTop: padding_top,
+        paddingBottom: padding_bottom,
+        textAlign: text_align,
+      }}
+    >
+      <div className="mx-auto" style={{ maxWidth: max_width }}>
+        <h2
+          className="font-semibold mb-2"
+          style={{ color: text_color, fontSize: `${title_font_size}px` }}
+        >
+          {title}
+        </h2>
+        <p style={{ color: subtle_text_color, fontSize: `${desc_font_size}px` }}>{text}</p>
+      </div>
+    </div>
+  )
+}
+
+export default AboutCompany

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/AboutCompanyPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/AboutCompanyPreview.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { PreviewWrapper } from '@preview/PreviewWrapper'
+import AboutCompany from './AboutCompany'
+import { applyCssVariablesFromUiSchema } from '@preview/utils/applyCssVariables'
+import { useSiteSettings } from '@/context/SiteSettingsContext'
+
+export default function AboutCompanyPreview({ settings = {}, data = {}, commonSettings = {} }) {
+  const { data: globalSiteData } = useSiteSettings()
+  const [styleVars, setStyleVars] = useState({})
+
+  useEffect(() => {
+    if (!globalSiteData?.ui_schema) return
+
+    if (settings?.custom_appearance) {
+      const vars = {}
+      Object.entries(settings).forEach(([key, val]) => {
+        if (key.includes('color') || key.startsWith('bg_')) {
+          vars[`--${key.replace(/_/g, '-')}`] = val
+        }
+      })
+
+      const varsJson = JSON.stringify(vars)
+      const styleVarsJson = JSON.stringify(styleVars)
+
+      if (varsJson !== styleVarsJson) {
+        setStyleVars(vars)
+      }
+    } else {
+      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+      if (Object.keys(styleVars).length > 0) {
+        setStyleVars({})
+      }
+    }
+  }, [settings, globalSiteData?.ui_schema])
+
+  return (
+    <PreviewWrapper>
+      <div style={styleVars}>
+        <AboutCompany settings={settings} data={data} commonSettings={commonSettings} />
+      </div>
+    </PreviewWrapper>
+  )
+}

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
@@ -1,15 +1,23 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSiteSettings } from '@/context/SiteSettingsContext'
 import { aboutSchema } from './aboutSchema'
+import { aboutDataSchema } from './aboutDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import TextItemsEditor from './ItemsEditor'
 import TextAppearance from './Appearance'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
+import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
-export default function TextEditor({ block, data, onChange, slug }) {
+export default function TextEditor({ block, slug, onChange }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
-  const [showToast, setShowToast] = useState(false)
+  const [dataState, setDataState] = useState(block?.data || {})
+  const [settingsState, setSettingsState] = useState(block?.settings || {})
+
+  useEffect(() => {
+    setDataState(block?.data || {})
+    setSettingsState(block?.settings || {})
+  }, [block])
 
   const {
     handleFieldChange,
@@ -20,24 +28,50 @@ export default function TextEditor({ block, data, onChange, slug }) {
     uiDefaults,
   } = useBlockAppearance({
     schema: aboutSchema,
-    data,
+    data: settingsState,
     block_id,
     slug,
     siteData,
     site_name,
     setData,
-    onChange,
+    onChange: update => {
+      setSettingsState(update)
+      onChange(prev => ({
+        ...prev,
+        settings:
+          typeof update === 'function' ? update(prev.settings || {}) : update,
+      }))
+    },
+  })
+
+  const {
+    handleFieldChange: handleDataChange,
+    handleSaveData,
+    showSavedToast: savedData,
+    resetButton: resetData,
+    showSaveButton: showDataButton,
+  } = useBlockData({
+    schema: aboutDataSchema,
+    data: dataState,
+    block_id,
+    slug,
+    site_name,
+    setData,
+    onChange: update => {
+      setDataState(update)
+      onChange(prev => ({
+        ...prev,
+        data: typeof update === 'function' ? update(prev.data || {}) : update,
+      }))
+    },
   })
 
   return (
     <div className="space-y-6 relative">
-      {showToast && (
-        <div className="absolute top-0 right-0 bg-green-100 text-green-800 px-3 py-1 rounded shadow text-sm transition-opacity duration-300">
-          ✅ Порядок сохранён
+      {(showSavedToast || savedData) && (
+        <div className="text-green-600 text-sm font-medium">
+          ✅ {showSavedToast ? 'Внешний вид' : 'Содержимое'} сохранено
         </div>
-      )}
-      {showSavedToast && (
-        <div className="text-green-600 text-sm font-medium">✅ Внешний вид сохранён</div>
       )}
 
       <div className="text-sm text-gray-500 italic pl-1">
@@ -45,21 +79,22 @@ export default function TextEditor({ block, data, onChange, slug }) {
       </div>
 
       <TextItemsEditor
-        settings={data}
-        siteName={site_name}
-        siteData={siteData}
-        setData={setData}
-        onChange={onChange}
-        setShowToast={setShowToast}
+        schema={aboutDataSchema}
+        data={dataState}
+        onTextChange={handleDataChange}
+        onSaveData={() => handleSaveData(dataState)}
+        showButton={showDataButton}
+        resetButton={resetData}
+        uiDefaults={uiDefaults}
       />
 
       <TextAppearance
         schema={aboutSchema}
-        settings={data}
+        settings={settingsState}
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
-        onSaveAppearance={handleSaveAppearance}
-        showButton={showSaveButton || data?.custom_appearance === false}
+        onSaveAppearance={() => handleSaveAppearance(settingsState)}
+        showButton={showSaveButton || settingsState?.custom_appearance === false}
         resetButton={resetButton}
         uiDefaults={uiDefaults}
       />

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/ItemsEditor.jsx
@@ -1,7 +1,59 @@
-export default function TextItemsEditor() {
+import { useEffect, useState } from 'react'
+import { fieldTypes } from '@/components/fields/fieldTypes'
+
+export default function TextItemsEditor({
+  schema = [],
+  data = {},
+  onTextChange,
+  onSaveData,
+  showButton,
+  resetButton,
+  uiDefaults = {},
+}) {
+  const [internalVisible, setInternalVisible] = useState(false)
+
+  useEffect(() => {
+    if (resetButton) {
+      setInternalVisible(false)
+      return
+    }
+
+    if (showButton) {
+      setInternalVisible(true)
+    }
+  }, [showButton, resetButton])
+
+  const renderField = field => {
+    if (!field.editable) return null
+
+    const fieldKey = field.key
+    const textVal = data?.[fieldKey] ?? uiDefaults?.[fieldKey] ?? field.default ?? ''
+    const FieldComponent = fieldTypes[field.type] || fieldTypes.text
+
+    return (
+      <FieldComponent
+        {...field}
+        key={fieldKey}
+        value={textVal}
+        onChange={val => onTextChange(fieldKey, val)}
+        label={field.label}
+      />
+    )
+  }
+
   return (
-    <div className="text-gray-400 text-sm italic pl-1">
-      🔧 Редактирование текста будет доступно позже
+    <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
+      {schema.map(renderField)}
+      {internalVisible && (
+        <div>
+          <button
+            onClick={onSaveData}
+            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+          >
+            💾 Сохранить содержимое блока
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/aboutDataSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/aboutDataSchema.js
@@ -1,0 +1,16 @@
+export const aboutDataSchema = [
+  {
+    key: 'title',
+    label: 'Заголовок',
+    type: 'text',
+    default: 'О компании',
+    editable: true,
+  },
+  {
+    key: 'text',
+    label: 'Текст',
+    type: 'textarea',
+    default: 'Мы доставляем горячую пиццу с любовью. Работаем с 10:00 до 23:00 каждый день.',
+    editable: true,
+  },
+]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/aboutSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/aboutSchema.js
@@ -1,4 +1,4 @@
-export const textSchema = [
+export const aboutSchema = [
   {
     key: 'custom_appearance',
     label: 'Изменить внешний вид блока (фон и цвета)',

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/blockMap.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/blockMap.js
@@ -7,6 +7,7 @@ import PopularItemsPreview from '@blocks/forms/PopularItems/PopularItemsPreview'
 import ReviewsPreview from '@blocks/forms/Reviews/ReviewsPreview'
 import DeliveryPreview from '@blocks/forms/Delivery/DeliveryPreview'
 import FooterPreview from '@blocks/forms/Footer/FooterPreview'
+import AboutCompanyPreview from '@blocks/forms/AboutCompany/AboutCompanyPreview'
 
 export const previewBlocks = {
   navigation: NavigationPreview,
@@ -17,6 +18,7 @@ export const previewBlocks = {
   products: PopularItemsPreview,
   reviews: ReviewsPreview,
   delivery: DeliveryPreview,
+  text: AboutCompanyPreview,
   footer: FooterPreview,
 }
 


### PR DESCRIPTION
## Summary
- enable editing content for AboutCompany block
- provide preview component for the text block
- hook up new block in preview map

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a6773816c83319e8587925fd18595