### PR TITLE
Show floating save button on changes

### DIFF
--- a/docs/git.md
+++ b/docs/git.md
@@ -2,7 +2,7 @@
 git fetch origin
 
 ### Подтяни коммит с помощью cherry-pick
-git cherry-pick 2aab3a0e93aa2c3ba9cf42ba28d4ebb8115ead94
+git cherry-pick 1806c2156acd2e227bac1aaaa10e9711bad6b243
 
 
 ### Жесткий сброс (удалит все локальные изменения навсегда)

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
@@ -8,7 +8,13 @@ import TextAppearance from './Appearance'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
-export default function TextEditor({ block, slug, onChange }) {
+export default function TextEditor({
+  block,
+  slug,
+  onChange,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
   const [dataState, setDataState] = useState(block?.data || {})
@@ -65,6 +71,17 @@ export default function TextEditor({ block, slug, onChange }) {
       }))
     },
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showSaveButton || showDataButton)
+  }, [onFloatingChange, showSaveButton, showDataButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: () => handleSaveData(dataState),
+      handleSaveAppearance: () => handleSaveAppearance(settingsState),
+    })
+  }, [onSaveHandlers, handleSaveData, handleSaveAppearance, dataState, settingsState])
 
   return (
     <div className="space-y-6 relative">

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
@@ -41,7 +41,7 @@ export default function TextEditor({
     site_name,
     setData,
     onChange: update => {
-      setSettingsState(update)
+      setSettingsState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => ({
         ...prev,
         settings:
@@ -64,7 +64,7 @@ export default function TextEditor({
     site_name,
     setData,
     onChange: update => {
-      setDataState(update)
+      setDataState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => ({
         ...prev,
         data: typeof update === 'function' ? update(prev.data || {}) : update,

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/ItemsEditor.jsx
@@ -44,16 +44,6 @@ export default function TextItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {schema.map(renderField)}
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
@@ -11,7 +11,13 @@ import BannerPreview from './BannerPreview'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
-export default function BannerEditor({ block, slug, onChange }) {
+export default function BannerEditor({
+  block,
+  slug,
+  onChange,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
 
@@ -76,6 +82,17 @@ export default function BannerEditor({ block, slug, onChange }) {
       })
     },
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showAppearanceButton || showDataButton)
+  }, [onFloatingChange, showAppearanceButton, showDataButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: () => handleSaveData(dataState),
+      handleSaveAppearance: () => handleSaveAppearance(settingsState),
+    })
+  }, [onSaveHandlers, handleSaveData, handleSaveAppearance, dataState, settingsState])
 
   return (
     <div className="space-y-6 relative">

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
@@ -45,7 +45,7 @@ export default function BannerEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setSettingsState(update)
+      setSettingsState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => {
         const resolved = typeof update === 'function' ? update(prev.settings || {}) : update
         return {
@@ -71,7 +71,7 @@ export default function BannerEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setDataState(update)
+      setDataState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => {
         const resolved = typeof update === 'function' ? update(prev.data || {}) : update
         return {

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/ItemsEditor.jsx
@@ -44,17 +44,6 @@ export default function BannerItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {schema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
@@ -8,7 +8,13 @@ import DeliveryAppearance from './Appearance'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
-export default function DeliveryEditor({ block, slug, onChange }) {
+export default function DeliveryEditor({
+  block,
+  slug,
+  onChange,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
 
@@ -65,6 +71,17 @@ export default function DeliveryEditor({ block, slug, onChange }) {
       }))
     },
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showAppearanceButton || showDataButton)
+  }, [onFloatingChange, showAppearanceButton, showDataButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: () => handleSaveData(dataState),
+      handleSaveAppearance: () => handleSaveAppearance(settingsState),
+    })
+  }, [onSaveHandlers, handleSaveData, handleSaveAppearance, dataState, settingsState])
 
   return (
     <div className="space-y-6 relative">

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
@@ -42,7 +42,7 @@ export default function DeliveryEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setSettingsState(update)
+      setSettingsState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => ({
         ...prev,
         settings: typeof update === 'function' ? update(prev.settings || {}) : update,
@@ -64,7 +64,7 @@ export default function DeliveryEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setDataState(update)
+      setDataState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => ({
         ...prev,
         data: typeof update === 'function' ? update(prev.data || {}) : update,

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/ItemsEditor.jsx
@@ -46,17 +46,6 @@ export default function DeliveryItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {limitedSchema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
@@ -43,7 +43,7 @@ export default function FooterEditor({
     site_name,
     setData,
     onChange: update => {
-      setSettingsState(update)
+      setSettingsState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => ({
         ...prev,
         settings: typeof update === 'function' ? update(prev.settings || {}) : update,
@@ -65,7 +65,7 @@ export default function FooterEditor({
     site_name,
     setData,
     onChange: update => {
-      setDataState(update)
+      setDataState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => ({
         ...prev,
         data: typeof update === 'function' ? update(prev.data || {}) : update,

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
@@ -8,7 +8,14 @@ import FooterAppearance from './Appearance'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
-export default function FooterEditor({ block, data, onChange, slug }) {
+export default function FooterEditor({
+  block,
+  data,
+  onChange,
+  slug,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
 
@@ -65,6 +72,17 @@ export default function FooterEditor({ block, data, onChange, slug }) {
       }))
     },
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showSaveButton || showDataButton)
+  }, [onFloatingChange, showSaveButton, showDataButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: () => handleSaveData(dataState),
+      handleSaveAppearance: () => handleSaveAppearance(settingsState),
+    })
+  }, [onSaveHandlers, handleSaveData, handleSaveAppearance, dataState, settingsState])
 
   return (
     <div className="space-y-6 relative">

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/ItemsEditor.jsx
@@ -44,17 +44,6 @@ export default function FooterItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {schema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Appearance.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Appearance.jsx
@@ -48,17 +48,6 @@ export default function NavigationAppearance({
   return (
     <div className="pt-4 border-t mt-6 space-y-4">
       {schema.map(field => field.editable && renderField(field))}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={() => onSaveAppearance?.(settings)}
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition text-sm"
-          >
-            📂 Сохранить внешний вид блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
@@ -10,7 +10,13 @@ import HeaderAppearance from './Appearance'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
-export default function HeaderEditor({ block, slug, onChange }) {
+export default function HeaderEditor({
+  block,
+  slug,
+  onChange,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
 
@@ -81,6 +87,17 @@ export default function HeaderEditor({ block, slug, onChange }) {
       })
     },
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showAppearanceButton || showDataButton)
+  }, [onFloatingChange, showAppearanceButton, showDataButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: () => handleSaveData(dataState),
+      handleSaveAppearance: () => handleSaveAppearance(settingsState),
+    })
+  }, [onSaveHandlers, handleSaveData, handleSaveAppearance, dataState, settingsState])
 
   const navigation = siteData?.navigation?.filter(n => n.block_id === block_id && n.visible) || []
 

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
@@ -44,7 +44,7 @@ export default function HeaderEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setSettingsState(update)
+      setSettingsState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prevBlockState => {
         const resolved =
           typeof update === 'function'
@@ -73,7 +73,7 @@ export default function HeaderEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setDataState(update)
+      setDataState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prevBlockState => {
         const resolved =
           typeof update === 'function'

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/ItemsEditor.jsx
@@ -44,17 +44,6 @@ export default function HeaderItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {schema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/Editor.jsx
@@ -6,7 +6,14 @@ import TabsItemsEditor from './ItemsEditor'
 import TabsAppearance from './Appearance'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 
-export default function TabsEditor({ block, data, onChange, slug }) {
+export default function TabsEditor({
+  block,
+  data,
+  onChange,
+  slug,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
   const [showToast, setShowToast] = useState(false)
@@ -28,6 +35,17 @@ export default function TabsEditor({ block, data, onChange, slug }) {
     setData,
     onChange,
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showSaveButton)
+  }, [onFloatingChange, showSaveButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: null,
+      handleSaveAppearance: () => handleSaveAppearance(data),
+    })
+  }, [onSaveHandlers, handleSaveAppearance, data])
 
   return (
     <div className="space-y-6 relative">

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/Editor.jsx
@@ -6,7 +6,14 @@ import NavigationItemsEditor from './ItemsEditor'
 import NavigationAppearance from './Appearance'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 
-export default function NavigationEditor({ block, data, onChange, slug }) {
+export default function NavigationEditor({
+  block,
+  data,
+  onChange,
+  slug,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
   const [items, setItems] = useState([])
@@ -40,6 +47,17 @@ export default function NavigationEditor({ block, data, onChange, slug }) {
     setData,
     onChange,
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showSaveButton)
+  }, [onFloatingChange, showSaveButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: null,
+      handleSaveAppearance: () => handleSaveAppearance(data),
+    })
+  }, [onSaveHandlers, handleSaveAppearance, data])
 
   return (
     <div className="space-y-6 relative">

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
@@ -9,7 +9,13 @@ import PopularItemsPreview from './PopularItemsPreview'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
-export default function ProductsEditor({ block, slug, onChange }) {
+export default function ProductsEditor({
+  block,
+  slug,
+  onChange,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
   const [dataState, setDataState] = useState(block?.data || {})
@@ -65,6 +71,17 @@ export default function ProductsEditor({ block, slug, onChange }) {
       })
     },
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showAppearanceButton || showDataButton)
+  }, [onFloatingChange, showAppearanceButton, showDataButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: () => handleSaveData(dataState),
+      handleSaveAppearance: () => handleSaveAppearance(settingsState),
+    })
+  }, [onSaveHandlers, handleSaveData, handleSaveAppearance, dataState, settingsState])
 
   return (
     <div className="space-y-6 relative">

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
@@ -42,7 +42,7 @@ export default function ProductsEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setSettingsState(update)
+      setSettingsState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => {
         const resolved = typeof update === 'function' ? update(prev.settings || {}) : update
         return { ...prev, ...resolved, settings: resolved }
@@ -64,7 +64,7 @@ export default function ProductsEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setDataState(update)
+      setDataState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => {
         const resolved = typeof update === 'function' ? update(prev.data || {}) : update
         return { ...prev, ...resolved, data: resolved }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/ItemsEditor.jsx
@@ -50,17 +50,6 @@ export default function ProductsItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {limitedSchema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/Editor.jsx
@@ -6,7 +6,14 @@ import ProductGridItemsEditor from './ItemsEditor'
 import ProductGridAppearance from './Appearance'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 
-export default function ProductGridEditor({ block, data, onChange, slug }) {
+export default function ProductGridEditor({
+  block,
+  data,
+  onChange,
+  slug,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
   const [showToast, setShowToast] = useState(false)
@@ -28,6 +35,17 @@ export default function ProductGridEditor({ block, data, onChange, slug }) {
     setData,
     onChange,
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showSaveButton)
+  }, [onFloatingChange, showSaveButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: null,
+      handleSaveAppearance: () => handleSaveAppearance(data),
+    })
+  }, [onSaveHandlers, handleSaveAppearance, data])
 
   return (
     <div className="space-y-6 relative">

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
@@ -45,7 +45,7 @@ export default function PromoEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setSettingsState(update)
+      setSettingsState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => ({ ...prev, settings: typeof update === 'function' ? update(prev.settings || {}) : update }))
     },
   })
@@ -64,7 +64,7 @@ export default function PromoEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setDataState(update)
+      setDataState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => ({ ...prev, data: typeof update === 'function' ? update(prev.data || {}) : update }))
     },
   })

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
@@ -9,7 +9,13 @@ import PromoCardsPreview from './PromoCardsPreview'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
-export default function PromoEditor({ block, slug, onChange }) {
+export default function PromoEditor({
+  block,
+  slug,
+  onChange,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
 
@@ -62,6 +68,17 @@ export default function PromoEditor({ block, slug, onChange }) {
       onChange(prev => ({ ...prev, data: typeof update === 'function' ? update(prev.data || {}) : update }))
     },
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showSaveButton || showDataButton)
+  }, [onFloatingChange, showSaveButton, showDataButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: () => handleSaveData(dataState),
+      handleSaveAppearance: () => handleSaveAppearance(settingsState),
+    })
+  }, [onSaveHandlers, handleSaveData, handleSaveAppearance, dataState, settingsState])
 
   return (
     <div className="space-y-6 relative">

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/ItemsEditor.jsx
@@ -52,17 +52,6 @@ export default function PromoItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {limitedSchema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
@@ -11,7 +11,13 @@ import QuickInfoAppearance from './Appearance'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
-export default function QuickInfoEditor({ block, slug, onChange }) {
+export default function QuickInfoEditor({
+  block,
+  slug,
+  onChange,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
   const [dataState, setDataState] = useState(block?.data || {})
@@ -77,6 +83,17 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
       })
     },
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showAppearanceButton || showDataButton)
+  }, [onFloatingChange, showAppearanceButton, showDataButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: () => handleSaveData(dataState),
+      handleSaveAppearance: () => handleSaveAppearance(settingsState),
+    })
+  }, [onSaveHandlers, handleSaveData, handleSaveAppearance, dataState, settingsState])
 
   return (
     <div className="space-y-6 relative">

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
@@ -44,7 +44,7 @@ export default function QuickInfoEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setSettingsState(update)
+      setSettingsState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => {
         const resolved =
           typeof update === 'function' ? update(prev.settings || {}) : update
@@ -71,7 +71,7 @@ export default function QuickInfoEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setDataState(update)
+      setDataState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => {
         const resolved =
           typeof update === 'function' ? update(prev.data || {}) : update

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/ItemsEditor.jsx
@@ -47,17 +47,6 @@ export default function QuickInfoItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {limitedSchema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
@@ -8,7 +8,13 @@ import ReviewsAppearance from './Appearance'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
-export default function ReviewsEditor({ block, slug, onChange }) {
+export default function ReviewsEditor({
+  block,
+  slug,
+  onChange,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
 
@@ -61,6 +67,17 @@ export default function ReviewsEditor({ block, slug, onChange }) {
       onChange(prev => ({ ...prev, data: typeof update === 'function' ? update(prev.data || {}) : update }))
     },
   })
+
+  useEffect(() => {
+    onFloatingChange?.(showSaveButton || showDataButton)
+  }, [onFloatingChange, showSaveButton, showDataButton])
+
+  useEffect(() => {
+    onSaveHandlers?.({
+      handleSaveData: () => handleSaveData(dataState),
+      handleSaveAppearance: () => handleSaveAppearance(settingsState),
+    })
+  }, [onSaveHandlers, handleSaveData, handleSaveAppearance, dataState, settingsState])
 
   return (
     <div className="space-y-6 relative">

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
@@ -44,7 +44,7 @@ export default function ReviewsEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setSettingsState(update)
+      setSettingsState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => ({ ...prev, settings: typeof update === 'function' ? update(prev.settings || {}) : update }))
     },
   })
@@ -63,7 +63,7 @@ export default function ReviewsEditor({
     site_name,
     setData,
     onChange: (update) => {
-      setDataState(update)
+      setDataState(prev => (typeof update === 'function' ? update(prev) : update))
       onChange(prev => ({ ...prev, data: typeof update === 'function' ? update(prev.data || {}) : update }))
     },
   })

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/ItemsEditor.jsx
@@ -52,17 +52,6 @@ export default function ReviewsItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {limitedSchema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
@@ -35,19 +35,14 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
     const values = {}
     for (const field of schema) {
       if (field.visible_if?.custom_appearance) {
-        values[field.key] = data[field.key] !== undefined ? data[field.key] : uiDefaults[field.key]
+        values[field.key] =
+          data[field.key] !== undefined ? data[field.key] : uiDefaults[field.key]
       }
     }
 
     setInitialAppearance(values)
-
-    requestAnimationFrame(() => {
-      const isChanged = schema.some(field => {
-        if (!field.visible_if?.custom_appearance) return false
-        return data[field.key] !== values[field.key]
-      })
-      setReadyToCheck(isChanged)
-    })
+    // do not flag changes when the block just opened
+    setReadyToCheck(false)
   }, [block_id])
 
   const handleFieldChange = (key, value) => {

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
@@ -83,11 +83,15 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
       const updated = { ...prev, [key]: value }
 
       if (prev.custom_appearance) {
-        const changed = schema.some(field => {
-          if (!field.visible_if?.custom_appearance) return false
-          return updated[field.key] !== initialAppearance[field.key]
-        })
-        requestAnimationFrame(() => setReadyToCheck(changed))
+        if (value !== prev[key]) {
+          requestAnimationFrame(() => setReadyToCheck(true))
+        } else {
+          const changed = schema.some(field => {
+            if (!field.visible_if?.custom_appearance) return false
+            return updated[field.key] !== initialAppearance[field.key]
+          })
+          requestAnimationFrame(() => setReadyToCheck(changed))
+        }
       }
 
       return updated

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
@@ -22,13 +22,18 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
   }, [block_id])
 
   const handleFieldChange = (key, value) => {
-    onChange((prev) => {
+    onChange(prev => {
       const updated = { ...prev, [key]: value }
 
-      const changed = schema.some(
-        (field) => updated[field.key] !== initialData[field.key]
-      )
-      setReadyToCheck(changed)
+      // react immediately when value differs from current state
+      if (value !== prev[key]) {
+        setReadyToCheck(true)
+      } else {
+        const anyChanged = schema.some(
+          (field) => updated[field.key] !== initialData[field.key]
+        )
+        setReadyToCheck(anyChanged)
+      }
 
       return updated
     })

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
@@ -14,11 +14,8 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
     }
 
     setInitialData(values)
-
-    const isChanged = schema.some(
-      (field) => data?.[field.key] !== values[field.key]
-    )
-    setReadyToCheck(isChanged)
+    // freshly opened blocks should not show the save button
+    setReadyToCheck(false)
   }, [block_id])
 
   const handleFieldChange = (key, value) => {

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
@@ -12,6 +12,11 @@ export default function PageEditor() {
   const [blocks, setBlocks] = useState([])
   const [blockDataMap, setBlockDataMap] = useState({})
   const [selectedId, setSelectedId] = useState(null)
+  const showFloating = true
+
+  const handleSaveAll = async () => {
+    // TODO: integrate actual save handlers
+  }
   const API_URL = import.meta.env.VITE_API_URL
 
   useEffect(() => {
@@ -29,27 +34,6 @@ export default function PageEditor() {
     setBlockDataMap(map)
   }, [data, slug])
 
-  const handleSave = async (blockId, newData) => {
-    const res = await fetch(`${API_URL}/sites/${site_name}/pages/${slug}/blocks/${blockId}`, {
-      method: 'PATCH',
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('access_token')}`,
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-      body: JSON.stringify(newData),
-    })
-    if (!res.ok) return alert('Не удалось сохранить данные')
-
-    setBlockDataMap(prev => ({ ...prev, [blockId]: newData }))
-    setData(prev => {
-      const updatedBlocks = prev.blocks?.[slug]?.map(b =>
-        b.real_id === blockId ? { ...b, settings: newData } : b
-      )
-      return { ...prev, blocks: { ...prev.blocks, [slug]: updatedBlocks } }
-    })
-    alert('Сохранено!')
-  }
 
   const handleReorder = async (newBlocks) => {
     const payload = newBlocks.map(({ real_id, order }) => ({ id: real_id, order }))
@@ -89,9 +73,16 @@ export default function PageEditor() {
         <BlockEditorPanel
           selectedBlock={selectedBlock}
           selectedData={selectedData}
-          onSave={handleSave}
         />
       </div>
+      {showFloating && (
+        <button
+          onClick={handleSaveAll}
+          className="fixed bottom-4 right-4 bg-blue-600 text-white px-4 py-2 rounded shadow-lg hover:bg-blue-700"
+        >
+          💾 Сохранить изменения
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useSiteSettings } from '@/context/SiteSettingsContext'
 
@@ -12,10 +12,12 @@ export default function PageEditor() {
   const [blocks, setBlocks] = useState([])
   const [blockDataMap, setBlockDataMap] = useState({})
   const [selectedId, setSelectedId] = useState(null)
-  const showFloating = true
+  const [showFloating, setShowFloating] = useState(false)
+  const saveHandlers = useRef({ handleSaveData: null, handleSaveAppearance: null })
 
   const handleSaveAll = async () => {
-    // TODO: integrate actual save handlers
+    await saveHandlers.current.handleSaveData?.()
+    await saveHandlers.current.handleSaveAppearance?.()
   }
   const API_URL = import.meta.env.VITE_API_URL
 
@@ -33,6 +35,11 @@ export default function PageEditor() {
     }
     setBlockDataMap(map)
   }, [data, slug])
+
+  useEffect(() => {
+    setShowFloating(false)
+    saveHandlers.current = { handleSaveData: null, handleSaveAppearance: null }
+  }, [selectedId])
 
 
   const handleReorder = async (newBlocks) => {
@@ -73,6 +80,10 @@ export default function PageEditor() {
         <BlockEditorPanel
           selectedBlock={selectedBlock}
           selectedData={selectedData}
+          onFloatingChange={setShowFloating}
+          onSaveHandlers={(h) => {
+            saveHandlers.current = h
+          }}
         />
       </div>
       {showFloating && (

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockAppearance.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockAppearance.jsx
@@ -1,27 +1,14 @@
-import { useEffect, useState } from 'react'
 
 export default function BlockAppearance({
   schema,
   settings,
   onChange,
   fieldTypes,
-  onSaveAppearance,
-  showButton,
-  resetButton,
+  onSaveAppearance: _onSaveAppearance,
+  showButton: _showButton,
+  resetButton: _resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-  const [isSaving, setIsSaving] = useState(false)
-
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) setInternalVisible(true)
-    if (!settings?.custom_appearance) setInternalVisible(false)
-  }, [showButton, settings?.custom_appearance, resetButton])
 
   const renderField = (field) => {
     if (field.visible_if) {
@@ -46,29 +33,9 @@ export default function BlockAppearance({
     )
   }
 
-  const handleClick = async () => {
-    setIsSaving(true)
-    await onSaveAppearance?.(settings)
-    setIsSaving(false)
-  }
-
   return (
     <div className="pt-4 border-t mt-6 space-y-4">
       {schema.map(field => field.editable && renderField(field))}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={handleClick}
-            disabled={isSaving}
-            className={`bg-blue-600 text-white px-4 py-2 rounded transition text-sm ${
-              isSaving ? 'opacity-50 cursor-not-allowed' : 'hover:bg-blue-700'
-            }`}
-          >
-            💾 Сохранить внешний вид блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
@@ -1,55 +1,19 @@
-import { useState } from 'react'
 import BlockDetails from '@/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails'
 
 export default function BlockEditorPanel({
   selectedBlock,
   selectedData,
-  handleSaveData,
-  handleSaveAppearance,
-  showSavedToast,
-  showButton,
+  onFloatingChange,
+  onSaveHandlers,
 }) {
-  const [saving, setSaving] = useState(false)
-  const [saved, setSaved] = useState(false)
-
-  const handleSaveBlock = async () => {
-    setSaving(true)
-    try {
-      await handleSaveData?.()
-      await handleSaveAppearance?.()
-      setSaved(true)
-      setTimeout(() => setSaved(false), 2000)
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  const disabled = (!showSavedToast && !showButton) || saving
-
   return (
     <div className="flex-1 border rounded p-4 bg-white shadow-sm min-h-[200px] overflow-x-auto space-y-4 relative">
       <BlockDetails
         block={selectedBlock}
         data={{ ...selectedData, block_id: selectedBlock?.real_id }}
+        onFloatingChange={onFloatingChange}
+        onSaveHandlers={onSaveHandlers}
       />
-
-      {showButton && (
-        <button
-          onClick={handleSaveBlock}
-          disabled={disabled}
-          className={`fixed bottom-6 right-6 z-50 bg-emerald-600 text-white px-5 py-3 rounded-full shadow-lg transition ${
-            disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-emerald-700'
-          }`}
-        >
-          💾 Сохранить блок
-        </button>
-      )}
-
-      {saved && (
-        <div className="text-green-600 text-sm absolute bottom-20 right-6 z-50">
-          ✅ Блок сохранён
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
@@ -1,13 +1,49 @@
+import { useState } from 'react'
 import BlockDetails from '@/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails'
 
-export default function BlockEditorPanel({ selectedBlock, selectedData, onSave }) {
+export default function BlockEditorPanel({
+  selectedBlock,
+  selectedData,
+  handleSaveData,
+  handleSaveAppearance,
+  showSavedToast,
+  showButton,
+}) {
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+
+  const handleSaveBlock = async () => {
+    setSaving(true)
+    try {
+      await handleSaveData?.()
+      await handleSaveAppearance?.()
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const disabled = (!showSavedToast && !showButton) || saving
+
   return (
-    <div className="flex-1 border rounded p-4 bg-white shadow-sm min-h-[200px] overflow-x-auto">
+    <div className="flex-1 border rounded p-4 bg-white shadow-sm min-h-[200px] overflow-x-auto space-y-4">
       <BlockDetails
         block={selectedBlock}
         data={{ ...selectedData, block_id: selectedBlock?.real_id }}
-        onSave={onSave}
       />
+
+      {showButton && (
+        <button
+          onClick={handleSaveBlock}
+          disabled={disabled}
+          className={`bg-emerald-600 text-white px-4 py-2 rounded text-sm transition ${disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-emerald-700'}`}
+        >
+          💾 Сохранить блок
+        </button>
+      )}
+
+      {saved && <div className="text-green-600 text-sm">✅ Блок сохранён</div>}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
@@ -27,7 +27,7 @@ export default function BlockEditorPanel({
   const disabled = (!showSavedToast && !showButton) || saving
 
   return (
-    <div className="flex-1 border rounded p-4 bg-white shadow-sm min-h-[200px] overflow-x-auto space-y-4">
+    <div className="flex-1 border rounded p-4 bg-white shadow-sm min-h-[200px] overflow-x-auto space-y-4 relative">
       <BlockDetails
         block={selectedBlock}
         data={{ ...selectedData, block_id: selectedBlock?.real_id }}
@@ -37,13 +37,19 @@ export default function BlockEditorPanel({
         <button
           onClick={handleSaveBlock}
           disabled={disabled}
-          className={`bg-emerald-600 text-white px-4 py-2 rounded text-sm transition ${disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-emerald-700'}`}
+          className={`fixed bottom-6 right-6 z-50 bg-emerald-600 text-white px-5 py-3 rounded-full shadow-lg transition ${
+            disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-emerald-700'
+          }`}
         >
           💾 Сохранить блок
         </button>
       )}
 
-      {saved && <div className="text-green-600 text-sm">✅ Блок сохранён</div>}
+      {saved && (
+        <div className="text-green-600 text-sm absolute bottom-20 right-6 z-50">
+          ✅ Блок сохранён
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -18,7 +18,13 @@ import DeliveryEditor from '@blocks/forms/Delivery'
 import AboutCompanyEditor from '@blocks/forms/AboutCompany'
 import FooterEditor from '@blocks/forms/Footer'
 
-export default function BlockDetails({ block, data, onSave }) {
+export default function BlockDetails({
+  block,
+  data,
+  onSave,
+  onFloatingChange,
+  onSaveHandlers,
+}) {
   const [form, setForm] = useState({})
   const [showPreview, setShowPreview] = useState(true)
   const { slug } = useParams()
@@ -92,6 +98,8 @@ export default function BlockDetails({ block, data, onSave }) {
     onChange: setForm,
     slug,
     site_name,
+    onFloatingChange,
+    onSaveHandlers,
   }
 
   const renderEditor = () => {


### PR DESCRIPTION
## Summary
- control floating save button based on block changes
- wire up save handlers from block editors
- remove old save button from BlockEditorPanel

## Testing
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684ab67af6dc83318555f475c887808b