### PR TITLE
Refactor save button behavior

### DIFF
--- a/docs/git.md
+++ b/docs/git.md
@@ -2,7 +2,7 @@
 git fetch origin
 
 ### Подтяни коммит с помощью cherry-pick
-git cherry-pick 2aab3a0e93aa2c3ba9cf42ba28d4ebb8115ead94
+git cherry-pick d846f0af26f59cc49fca8ee8906db998f2db3cf3
 
 
 ### Жесткий сброс (удалит все локальные изменения навсегда)

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
@@ -23,7 +23,6 @@ export default function TextEditor({ block, slug, onChange }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast,
-    resetButton,
     showSaveButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -48,7 +47,6 @@ export default function TextEditor({ block, slug, onChange }) {
     handleFieldChange: handleDataChange,
     handleSaveData,
     showSavedToast: savedData,
-    resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
     schema: aboutDataSchema,
@@ -83,8 +81,6 @@ export default function TextEditor({ block, slug, onChange }) {
         data={dataState}
         onTextChange={handleDataChange}
         onSaveData={() => handleSaveData(dataState)}
-        showButton={showDataButton}
-        resetButton={resetData}
         uiDefaults={uiDefaults}
       />
 
@@ -94,10 +90,20 @@ export default function TextEditor({ block, slug, onChange }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        showButton={showSaveButton || settingsState?.custom_appearance === false}
-        resetButton={resetButton}
         uiDefaults={uiDefaults}
       />
+
+      {(showDataButton || showSaveButton) && (
+        <button
+          onClick={() => {
+            if (showDataButton) handleSaveData(dataState)
+            if (showSaveButton) handleSaveAppearance(settingsState)
+          }}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/ItemsEditor.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+
 import { fieldTypes } from '@/components/fields/fieldTypes'
 
 export default function TextItemsEditor({
@@ -6,22 +6,8 @@ export default function TextItemsEditor({
   data = {},
   onTextChange,
   onSaveData,
-  showButton,
-  resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) {
-      setInternalVisible(true)
-    }
-  }, [showButton, resetButton])
 
   const renderField = field => {
     if (!field.editable) return null
@@ -44,16 +30,6 @@ export default function TextItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {schema.map(renderField)}
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
@@ -27,7 +27,6 @@ export default function BannerEditor({ block, slug, onChange }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast: savedAppearance,
-    resetButton: resetAppearance,
     showSaveButton: showAppearanceButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -55,7 +54,6 @@ export default function BannerEditor({ block, slug, onChange }) {
     handleFieldChange: handleTextFieldChange,
     handleSaveData,
     showSavedToast: savedData,
-    resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
     schema: bannerDataSchema,
@@ -90,8 +88,6 @@ export default function BannerEditor({ block, slug, onChange }) {
         data={dataState}
         onTextChange={handleTextFieldChange}
         onSaveData={() => handleSaveData(dataState)}
-        showButton={showDataButton}
-        resetButton={resetData}
       />
 
       <div className="text-sm text-gray-500 italic pl-1 pt-4 border-t">
@@ -104,10 +100,20 @@ export default function BannerEditor({ block, slug, onChange }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        showButton={showAppearanceButton || settingsState?.custom_appearance === false}
-        resetButton={resetAppearance}
         uiDefaults={uiDefaults}
       />
+
+      {(showDataButton || showAppearanceButton) && (
+        <button
+          onClick={() => {
+            if (showDataButton) handleSaveData(dataState)
+            if (showAppearanceButton) handleSaveAppearance(settingsState)
+          }}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
 
     </div>
   )

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
@@ -17,6 +17,7 @@ export default function BannerEditor({ block, slug, onChange }) {
 
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
+  const [canShow, setCanShow] = useState(false)
 
   useEffect(() => {
     setDataState(block?.data || {})
@@ -75,6 +76,15 @@ export default function BannerEditor({ block, slug, onChange }) {
     },
   })
 
+  useEffect(() => {
+    setCanShow(showDataButton || showAppearanceButton)
+  }, [showDataButton, showAppearanceButton])
+
+  console.log('🧪 showDataButton:', showDataButton)
+  console.log('🧪 showAppearanceButton:', showAppearanceButton)
+  console.log('🧪 settingsState.custom_appearance:', settingsState?.custom_appearance)
+  console.log('🧪 dataState:', dataState)
+
   return (
     <div className="space-y-6 relative">
       {(savedAppearance || savedData) && (
@@ -103,7 +113,7 @@ export default function BannerEditor({ block, slug, onChange }) {
         uiDefaults={uiDefaults}
       />
 
-      {(showDataButton || showAppearanceButton) && (
+      {canShow && (
         <button
           onClick={() => {
             if (showDataButton) handleSaveData(dataState)
@@ -114,7 +124,6 @@ export default function BannerEditor({ block, slug, onChange }) {
           💾 Сохранить
         </button>
       )}
-
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/ItemsEditor.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+
 import { fieldTypes } from '@/components/fields/fieldTypes'
 
 export default function BannerItemsEditor({
@@ -6,22 +6,8 @@ export default function BannerItemsEditor({
   data,
   onTextChange,
   onSaveData,
-  showButton,
-  resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) {
-      setInternalVisible(true)
-    }
-  }, [showButton, resetButton])
 
   const renderField = (field) => {
     if (!field.editable) return null
@@ -44,17 +30,6 @@ export default function BannerItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {schema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
@@ -24,7 +24,6 @@ export default function DeliveryEditor({ block, slug, onChange }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast: savedAppearance,
-    resetButton: resetAppearance,
     showSaveButton: showAppearanceButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -48,7 +47,6 @@ export default function DeliveryEditor({ block, slug, onChange }) {
     handleFieldChange: handleTextFieldChange,
     handleSaveData,
     showSavedToast: savedData,
-    resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
     schema: deliveryDataSchema,
@@ -79,8 +77,6 @@ export default function DeliveryEditor({ block, slug, onChange }) {
         data={dataState}
         onTextChange={handleTextFieldChange}
         onSaveData={() => handleSaveData(dataState)}
-        showButton={showDataButton}
-        resetButton={resetData}
         uiDefaults={uiDefaults}
       />
 
@@ -94,10 +90,20 @@ export default function DeliveryEditor({ block, slug, onChange }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        showButton={showAppearanceButton || settingsState?.custom_appearance === false}
-        resetButton={resetAppearance}
         uiDefaults={uiDefaults}
       />
+
+      {(showDataButton || showAppearanceButton) && (
+        <button
+          onClick={() => {
+            if (showDataButton) handleSaveData(dataState)
+            if (showAppearanceButton) handleSaveAppearance(settingsState)
+          }}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/ItemsEditor.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+
 import { fieldTypes } from '@/components/fields/fieldTypes'
 
 export default function DeliveryItemsEditor({
@@ -6,22 +6,8 @@ export default function DeliveryItemsEditor({
   data,
   onTextChange,
   onSaveData,
-  showButton,
-  resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) {
-      setInternalVisible(true)
-    }
-  }, [showButton, resetButton])
 
   const limitedSchema = Array.isArray(schema) ? schema : []
 
@@ -46,17 +32,6 @@ export default function DeliveryItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {limitedSchema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
@@ -24,7 +24,6 @@ export default function FooterEditor({ block, data, onChange, slug }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast,
-    resetButton,
     showSaveButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -48,7 +47,6 @@ export default function FooterEditor({ block, data, onChange, slug }) {
     handleFieldChange: handleDataChange,
     handleSaveData,
     showSavedToast: savedData,
-    resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
     schema: createFooterDataSchema(settingsState?.show_social_icons),
@@ -83,8 +81,6 @@ export default function FooterEditor({ block, data, onChange, slug }) {
         data={dataState}
         onTextChange={handleDataChange}
         onSaveData={() => handleSaveData(dataState)}
-        showButton={showDataButton}
-        resetButton={resetData}
         uiDefaults={uiDefaults}
       />
 
@@ -94,10 +90,20 @@ export default function FooterEditor({ block, data, onChange, slug }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        showButton={showSaveButton || settingsState?.custom_appearance === false}
-        resetButton={resetButton}
         uiDefaults={uiDefaults}
       />
+
+      {(showDataButton || showSaveButton) && (
+        <button
+          onClick={() => {
+            if (showDataButton) handleSaveData(dataState)
+            if (showSaveButton) handleSaveAppearance(settingsState)
+          }}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/ItemsEditor.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+
 import { fieldTypes } from '@/components/fields/fieldTypes'
 
 export default function FooterItemsEditor({
@@ -6,22 +6,8 @@ export default function FooterItemsEditor({
   data = {},
   onTextChange,
   onSaveData,
-  showButton,
-  resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) {
-      setInternalVisible(true)
-    }
-  }, [showButton, resetButton])
 
   const renderField = field => {
     if (!field.editable) return null
@@ -44,17 +30,6 @@ export default function FooterItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {schema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Appearance.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Appearance.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+
 
 export default function NavigationAppearance({
   schema,
@@ -6,21 +6,8 @@ export default function NavigationAppearance({
   onChange,
   fieldTypes,
   onSaveAppearance,
-  showButton,
-  resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) setInternalVisible(true)
-    if (!settings?.custom_appearance) setInternalVisible(false)
-  }, [showButton, settings?.custom_appearance, resetButton])
 
   const renderField = (field) => {
     if (field.visible_if) {
@@ -48,17 +35,6 @@ export default function NavigationAppearance({
   return (
     <div className="pt-4 border-t mt-6 space-y-4">
       {schema.map(field => field.editable && renderField(field))}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={() => onSaveAppearance?.(settings)}
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition text-sm"
-          >
-            📂 Сохранить внешний вид блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
@@ -26,7 +26,6 @@ export default function HeaderEditor({ block, slug, onChange }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast: savedAppearance,
-    resetButton: resetAppearance,
     showSaveButton: showAppearanceButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -57,7 +56,6 @@ export default function HeaderEditor({ block, slug, onChange }) {
     handleFieldChange: handleTextFieldChange,
     handleSaveData,
     showSavedToast: savedData,
-    resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
     schema: headerDataSchema,
@@ -100,8 +98,6 @@ export default function HeaderEditor({ block, slug, onChange }) {
         onColorChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveData={() => handleSaveData(dataState)}
-        showButton={showDataButton}
-        resetButton={resetData}
       />
 
       <div className="text-sm text-gray-500 italic pl-1 pt-4 border-t">
@@ -114,10 +110,20 @@ export default function HeaderEditor({ block, slug, onChange }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        showButton={showAppearanceButton || settingsState?.custom_appearance === false}
-        resetButton={resetAppearance}
         uiDefaults={uiDefaults}
       />
+
+      {(showDataButton || showAppearanceButton) && (
+        <button
+          onClick={() => {
+            if (showDataButton) handleSaveData(dataState)
+            if (showAppearanceButton) handleSaveAppearance(settingsState)
+          }}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
 
     </div>
   )

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/ItemsEditor.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+
 import { fieldTypes } from '@/components/fields/fieldTypes'
 
 export default function HeaderItemsEditor({
@@ -6,22 +6,8 @@ export default function HeaderItemsEditor({
   data,
   onTextChange,
   onSaveData,
-  showButton,
-  resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) {
-      setInternalVisible(true)
-    }
-  }, [showButton, resetButton])
 
   const renderField = (field) => {
     if (!field.editable) return null
@@ -44,17 +30,6 @@ export default function HeaderItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {schema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/Editor.jsx
@@ -15,7 +15,6 @@ export default function TabsEditor({ block, data, onChange, slug }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast,
-    resetButton,
     showSaveButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -59,10 +58,17 @@ export default function TabsEditor({ block, data, onChange, slug }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={handleSaveAppearance}
-        showButton={showSaveButton || data?.custom_appearance === false}
-        resetButton={resetButton}
         uiDefaults={uiDefaults}
       />
+
+      {showSaveButton && (
+        <button
+          onClick={() => handleSaveAppearance(data)}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/Editor.jsx
@@ -27,7 +27,6 @@ export default function NavigationEditor({ block, data, onChange, slug }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast,
-    resetButton,
     showSaveButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -72,10 +71,17 @@ export default function NavigationEditor({ block, data, onChange, slug }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={handleSaveAppearance}
-        showButton={showSaveButton || data?.custom_appearance === false}
-        resetButton={resetButton}
         uiDefaults={uiDefaults}
       />
+
+      {showSaveButton && (
+        <button
+          onClick={() => handleSaveAppearance(data)}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
@@ -24,7 +24,6 @@ export default function ProductsEditor({ block, slug, onChange }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast: savedAppearance,
-    resetButton: resetAppearance,
     showSaveButton: showAppearanceButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -48,7 +47,6 @@ export default function ProductsEditor({ block, slug, onChange }) {
     handleFieldChange: handleDataChange,
     handleSaveData,
     showSavedToast: savedData,
-    resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
     schema: createProductsDataSchema(settingsState?.cards_count || 3),
@@ -84,8 +82,6 @@ export default function ProductsEditor({ block, slug, onChange }) {
         settings={settingsState}
         onTextChange={handleDataChange}
         onSaveData={() => handleSaveData(dataState)}
-        showButton={showDataButton}
-        resetButton={resetData}
         uiDefaults={uiDefaults}
       />
 
@@ -95,10 +91,20 @@ export default function ProductsEditor({ block, slug, onChange }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        showButton={showAppearanceButton || settingsState?.custom_appearance === false}
-        resetButton={resetAppearance}
         uiDefaults={uiDefaults}
       />
+
+      {(showDataButton || showAppearanceButton) && (
+        <button
+          onClick={() => {
+            if (showDataButton) handleSaveData(dataState)
+            if (showAppearanceButton) handleSaveAppearance(settingsState)
+          }}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
 
 
     </div>

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/ItemsEditor.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+
 import { fieldTypes } from '@/components/fields/fieldTypes'
 
 export default function ProductsItemsEditor({
@@ -7,22 +7,8 @@ export default function ProductsItemsEditor({
   settings = {},
   onTextChange,
   onSaveData,
-  showButton,
-  resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) {
-      setInternalVisible(true)
-    }
-  }, [showButton, resetButton])
 
   const count = settings?.cards_count || (schema.length - 1) / 3
   const limitedSchema = Array.isArray(schema)
@@ -50,17 +36,6 @@ export default function ProductsItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {limitedSchema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/Editor.jsx
@@ -15,7 +15,6 @@ export default function ProductGridEditor({ block, data, onChange, slug }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast,
-    resetButton,
     showSaveButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -59,10 +58,17 @@ export default function ProductGridEditor({ block, data, onChange, slug }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={handleSaveAppearance}
-        showButton={showSaveButton || data?.custom_appearance === false}
-        resetButton={resetButton}
         uiDefaults={uiDefaults}
       />
+
+      {showSaveButton && (
+        <button
+          onClick={() => handleSaveAppearance(data)}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
@@ -27,7 +27,6 @@ export default function PromoEditor({ block, slug, onChange }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast,
-    resetButton,
     showSaveButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -48,7 +47,6 @@ export default function PromoEditor({ block, slug, onChange }) {
     handleFieldChange: handleDataChange,
     handleSaveData,
     showSavedToast: savedData,
-    resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
     schema: promoDataSchema,
@@ -86,8 +84,6 @@ export default function PromoEditor({ block, slug, onChange }) {
         settings={settingsState}
         onTextChange={handleDataChange}
         onSaveData={() => handleSaveData(dataState)}
-        showButton={showDataButton}
-        resetButton={resetData}
         uiDefaults={uiDefaults}
       />
 
@@ -97,10 +93,20 @@ export default function PromoEditor({ block, slug, onChange }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        showButton={showSaveButton || settingsState?.custom_appearance === false}
-        resetButton={resetButton}
         uiDefaults={uiDefaults}
       />
+
+      {(showDataButton || showSaveButton) && (
+        <button
+          onClick={() => {
+            if (showDataButton) handleSaveData(dataState)
+            if (showSaveButton) handleSaveAppearance(settingsState)
+          }}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
 
     </div>
   )

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/ItemsEditor.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+
 import { fieldTypes } from '@/components/fields/fieldTypes'
 
 export default function PromoItemsEditor({
@@ -7,22 +7,8 @@ export default function PromoItemsEditor({
   settings = {},
   onTextChange,
   onSaveData,
-  showButton,
-  resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) {
-      setInternalVisible(true)
-    }
-  }, [showButton, resetButton])
 
   const fieldsPerCard = 3
   const defaultCards = schema.length / fieldsPerCard
@@ -52,17 +38,6 @@ export default function PromoItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {limitedSchema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
@@ -26,7 +26,6 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast: savedAppearance,
-    resetButton: resetAppearance,
     showSaveButton: showAppearanceButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -55,7 +54,6 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
     handleFieldChange: handleTextFieldChange,
     handleSaveData,
     showSavedToast: savedData,
-    resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
     schema: createQuickInfoDataSchema(settingsState?.grid_cols || 4),
@@ -96,8 +94,6 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
         settings={settingsState}
         onTextChange={handleTextFieldChange}
         onSaveData={() => handleSaveData(dataState)}
-        showButton={showDataButton}
-        resetButton={resetData}
         uiDefaults={uiDefaults}
       />
 
@@ -107,12 +103,20 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        showButton={showAppearanceButton || settingsState?.custom_appearance === false}
-        resetButton={resetAppearance}
         uiDefaults={uiDefaults}
       />
 
-
+      {(showDataButton || showAppearanceButton) && (
+        <button
+          onClick={() => {
+            if (showDataButton) handleSaveData(dataState)
+            if (showAppearanceButton) handleSaveAppearance(settingsState)
+          }}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/ItemsEditor.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+
 import { fieldTypes } from '@/components/fields/fieldTypes'
 
 export default function QuickInfoItemsEditor({
@@ -7,22 +7,8 @@ export default function QuickInfoItemsEditor({
   settings = {},
   onTextChange,
   onSaveData,
-  showButton,
-  resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) {
-      setInternalVisible(true)
-    }
-  }, [showButton, resetButton])
 
   const limitedSchema = Array.isArray(schema) ? schema : []
 
@@ -47,17 +33,6 @@ export default function QuickInfoItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {limitedSchema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
@@ -26,7 +26,6 @@ export default function ReviewsEditor({ block, slug, onChange }) {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast,
-    resetButton,
     showSaveButton,
     uiDefaults,
   } = useBlockAppearance({
@@ -47,7 +46,6 @@ export default function ReviewsEditor({ block, slug, onChange }) {
     handleFieldChange: handleDataChange,
     handleSaveData,
     showSavedToast: savedData,
-    resetButton: resetData,
     showSaveButton: showDataButton,
   } = useBlockData({
     schema: createReviewsDataSchema(settingsState?.reviews_count || 4),
@@ -85,8 +83,6 @@ export default function ReviewsEditor({ block, slug, onChange }) {
         settings={settingsState}
         onTextChange={handleDataChange}
         onSaveData={() => handleSaveData(dataState)}
-        showButton={showDataButton}
-        resetButton={resetData}
         uiDefaults={uiDefaults}
       />
 
@@ -96,10 +92,20 @@ export default function ReviewsEditor({ block, slug, onChange }) {
         onChange={handleFieldChange}
         fieldTypes={fieldTypes}
         onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        showButton={showSaveButton || settingsState?.custom_appearance === false}
-        resetButton={resetButton}
         uiDefaults={uiDefaults}
       />
+
+      {(showDataButton || showSaveButton) && (
+        <button
+          onClick={() => {
+            if (showDataButton) handleSaveData(dataState)
+            if (showSaveButton) handleSaveAppearance(settingsState)
+          }}
+          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/ItemsEditor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/ItemsEditor.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+
 import { fieldTypes } from '@/components/fields/fieldTypes'
 
 export default function ReviewsItemsEditor({
@@ -7,22 +7,8 @@ export default function ReviewsItemsEditor({
   settings = {},
   onTextChange,
   onSaveData,
-  showButton,
-  resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) {
-      setInternalVisible(true)
-    }
-  }, [showButton, resetButton])
 
   const fieldsPerReview = 4
   const defaultReviews = schema.length / fieldsPerReview
@@ -52,17 +38,6 @@ export default function ReviewsItemsEditor({
   return (
     <div className="pt-4 border-t mt-6 space-y-4 relative z-0">
       {limitedSchema.map(renderField)}
-
-      {internalVisible && (
-        <div>
-          <button
-            onClick={onSaveData}
-            className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-          >
-            💾 Сохранить содержимое блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
@@ -42,7 +42,17 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
       setReadyToCheck(false)
       return
     }
-    const values = getValues(data)
+
+    const values = {}
+    for (const field of schema) {
+      if (field.visible_if?.custom_appearance) {
+        values[field.key] =
+          data[field.key] !== undefined
+            ? data[field.key]
+            : uiDefaults[field.key]
+      }
+    }
+
     setInitialAppearance(values)
     setReadyToCheck(false)
   }, [block_id])
@@ -101,7 +111,7 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
           const initVal = normalize(initialAppearance[field.key])
           return newVal !== initVal
         })
-        requestAnimationFrame(() => setReadyToCheck(changed))
+        setReadyToCheck(changed)
       }
 
       return updated
@@ -110,6 +120,7 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
 
   const hasAppearanceChanged = () => {
     if (!readyToCheck || !data?.custom_appearance) return false
+    if (!Object.keys(initialAppearance).length) return false
     return schema.some(field => {
       if (!field.visible_if?.custom_appearance) return false
       const current = normalize(data[field.key])

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
@@ -25,6 +25,8 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
     uiDefaults.background_color = uiDefaults.bg_color
   }
 
+  const normalize = (val) => (val !== undefined ? val : '')
+
   useEffect(() => {
     if (!data?.custom_appearance) {
       setInitialAppearance({})
@@ -35,19 +37,12 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
     const values = {}
     for (const field of schema) {
       if (field.visible_if?.custom_appearance) {
-        values[field.key] = data[field.key] !== undefined ? data[field.key] : uiDefaults[field.key]
+        values[field.key] = normalize(data[field.key])
       }
     }
 
     setInitialAppearance(values)
-
-    requestAnimationFrame(() => {
-      const isChanged = schema.some(field => {
-        if (!field.visible_if?.custom_appearance) return false
-        return data[field.key] !== values[field.key]
-      })
-      setReadyToCheck(isChanged)
-    })
+    setReadyToCheck(false)
   }, [block_id])
 
   const handleFieldChange = (key, value) => {
@@ -85,7 +80,9 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
       if (prev.custom_appearance) {
         const changed = schema.some(field => {
           if (!field.visible_if?.custom_appearance) return false
-          return updated[field.key] !== initialAppearance[field.key]
+          const newVal = updated[field.key] !== undefined ? updated[field.key] : ''
+          const initVal = initialAppearance[field.key] !== undefined ? initialAppearance[field.key] : ''
+          return newVal !== initVal
         })
         requestAnimationFrame(() => setReadyToCheck(changed))
       }
@@ -98,7 +95,9 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
     if (!readyToCheck || !data?.custom_appearance) return false
     return schema.some(field => {
       if (!field.visible_if?.custom_appearance) return false
-      return data[field.key] !== initialAppearance[field.key]
+      const current = data[field.key] !== undefined ? data[field.key] : ''
+      const initVal = initialAppearance[field.key] !== undefined ? initialAppearance[field.key] : ''
+      return current !== initVal
     })
   }
 

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
@@ -43,6 +43,14 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
 
     setInitialAppearance(values)
     setReadyToCheck(false)
+
+    const changed = schema.some(field => {
+      if (!field.visible_if?.custom_appearance) return false
+      const current = normalize(data[field.key])
+      const initVal = normalize(values[field.key])
+      return current !== initVal
+    })
+    setReadyToCheck(changed)
   }, [block_id])
 
   const handleFieldChange = (key, value) => {
@@ -80,8 +88,8 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
       if (prev.custom_appearance) {
         const changed = schema.some(field => {
           if (!field.visible_if?.custom_appearance) return false
-          const newVal = updated[field.key] !== undefined ? updated[field.key] : ''
-          const initVal = initialAppearance[field.key] !== undefined ? initialAppearance[field.key] : ''
+          const newVal = normalize(updated[field.key])
+          const initVal = normalize(initialAppearance[field.key])
           return newVal !== initVal
         })
         requestAnimationFrame(() => setReadyToCheck(changed))
@@ -95,8 +103,8 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
     if (!readyToCheck || !data?.custom_appearance) return false
     return schema.some(field => {
       if (!field.visible_if?.custom_appearance) return false
-      const current = data[field.key] !== undefined ? data[field.key] : ''
-      const initVal = initialAppearance[field.key] !== undefined ? initialAppearance[field.key] : ''
+      const current = normalize(data[field.key])
+      const initVal = normalize(initialAppearance[field.key])
       return current !== initVal
     })
   }
@@ -156,7 +164,7 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
     }
   }
 
-  const showSaveButton = readyToCheck && data?.custom_appearance && hasAppearanceChanged()
+  const showSaveButton = data?.custom_appearance ? (readyToCheck && hasAppearanceChanged()) : false
   console.log('[🔥 uiDefaults]', uiDefaults)
 
   return {

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
@@ -29,7 +29,6 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
     }
   }
 
-  // авто-синхронизация синонимов
   if (uiDefaults.background_color && !uiDefaults.bg_color) {
     uiDefaults.bg_color = uiDefaults.background_color
   }
@@ -46,12 +45,9 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
     const values = getValues(data)
     setInitialAppearance(values)
     setReadyToCheck(false)
+  }, [block_id])
 
   useEffect(() => {
-    if (!readyToCheck) {
-      setInitialAppearance(getValues(data))
-    }
-
     if (!data?.custom_appearance) {
       setReadyToCheck(false)
       return
@@ -59,21 +55,12 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
 
     const changed = schema.some(field => {
       if (!field.visible_if?.custom_appearance) return false
-      const current = data[field.key] !== undefined ? data[field.key] : ''
-      const initVal = initialAppearance[field.key] !== undefined ? initialAppearance[field.key] : ''
+      const current = normalize(data[field.key])
+      const initVal = normalize(initialAppearance[field.key])
       return current !== initVal
     })
     setReadyToCheck(changed)
   }, [data])
-
-    const changed = schema.some(field => {
-      if (!field.visible_if?.custom_appearance) return false
-      const current = normalize(data[field.key])
-      const initVal = normalize(values[field.key])
-      return current !== initVal
-    })
-    setReadyToCheck(changed)
-  }, [block_id])
 
   const handleFieldChange = (key, value) => {
     if (key === 'custom_appearance' && value === false) {

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
@@ -11,20 +11,31 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
     return values
   }
 
-  const [initialData, setInitialData] = useState(getValues(data))
+  const [initialData, setInitialData] = useState({})
   const [readyToCheck, setReadyToCheck] = useState(false)
   const [showSavedToast, setShowSavedToast] = useState(false)
   const [resetButton, setResetButton] = useState(false)
   const [justMounted, setJustMounted] = useState(true)
+  const [initialized, setInitialized] = useState(false)
 
   useEffect(() => {
-    setInitialData(getValues(data))
+    // ждём, пока все поля будут не пустыми
+    const allFieldsReady = schema.every(f => {
+      const val = data?.[f.key]
+      return val !== undefined && val !== ''
+    })
+
+    if (!allFieldsReady) return
+
+    const values = getValues(data)
+    setInitialData(values)
     setReadyToCheck(false)
     setJustMounted(true)
-  }, [block_id])
+    setInitialized(true)
+  }, [block_id, data])
 
   useEffect(() => {
-    if (justMounted) {
+    if (!initialized || justMounted) {
       setJustMounted(false)
       return
     }
@@ -32,8 +43,14 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
     const changed = schema.some((field) => {
       const current = normalize(data?.[field.key])
       const initVal = normalize(initialData[field.key])
+      if (current !== initVal) {
+        console.log(`[🧨 Изменено поле]: ${field.key}`)
+        console.log('  └ current:', current)
+        console.log('  └ initial:', initVal)
+      }
       return current !== initVal
     })
+
     setReadyToCheck(changed)
   }, [data])
 
@@ -46,8 +63,8 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
         const initVal = normalize(initialData[field.key])
         return newVal !== initVal
       })
-      setReadyToCheck(changed)
 
+      setReadyToCheck(changed)
       return updated
     })
   }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
@@ -1,90 +1,85 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef, useCallback } from 'react';
 
 export function useBlockData({ schema, data, block_id, slug, site_name, setData, onChange }) {
-  const normalize = (val) => (val !== undefined ? val : '')
+  // Helper to normalize values (undefined -> '', useful for consistent comparisons)
+  const normalize = useCallback((val) => (val !== undefined && val !== null ? val : ''), []);
 
-  const getValues = (source = {}) => {
-    const values = {}
-    for (const field of schema) {
-      values[field.key] = normalize(source[field.key])
-    }
-    return values
-  }
+  // initialData will hold the data as it was when the component first loaded or after a successful save.
+  const [initialData, setInitialData] = useState({});
+  const [showSavedToast, setShowSavedToast] = useState(false);
+  const [resetButton, setResetButton] = useState(false);
 
-  const [initialData, setInitialData] = useState({})
-  const [readyToCheck, setReadyToCheck] = useState(false)
-  const [showSavedToast, setShowSavedToast] = useState(false)
-  const [resetButton, setResetButton] = useState(false)
-  const [justMounted, setJustMounted] = useState(true)
-  const [initialized, setInitialized] = useState(false)
+  // A ref to track if initialData has been set for the current block_id,
+  // preventing it from being set multiple times on re-renders for the same block.
+  const initialDataInitializedRef = useRef(false);
+  const currentBlockIdRef = useRef(null); // To track which block_id initialData corresponds to
 
+  // Effect to initialize `initialData` when the component mounts or `block_id` changes.
   useEffect(() => {
-    // ждём, пока все поля будут не пустыми
-    const allFieldsReady = schema.every(f => {
-      const val = data?.[f.key]
-      return val !== undefined && val !== ''
-    })
-
-    if (!allFieldsReady) return
-
-    const values = getValues(data)
-    setInitialData(values)
-    setReadyToCheck(false)
-    setJustMounted(true)
-    setInitialized(true)
-  }, [block_id, data])
-
-  useEffect(() => {
-    if (!initialized || justMounted) {
-      setJustMounted(false)
-      return
+    // If block_id changes, reset initialization status
+    if (currentBlockIdRef.current !== block_id) {
+      initialDataInitializedRef.current = false;
+      currentBlockIdRef.current = block_id;
     }
 
-    const changed = schema.some((field) => {
-      const current = normalize(data?.[field.key])
-      const initVal = normalize(initialData[field.key])
-      if (current !== initVal) {
-        console.log(`[🧨 Изменено поле]: ${field.key}`)
-        console.log('  └ current:', current)
-        console.log('  └ initial:', initVal)
+    // Only initialize if not already initialized for this block_id
+    if (!initialDataInitializedRef.current) {
+      // Wait until all fields in `data` are defined/non-empty before setting initialData.
+      // This prevents capturing incomplete data as the "initial" state.
+      const allFieldsReady = schema.every(f => {
+        const val = data?.[f.key];
+        return val !== undefined && val !== null; // Check for null as well
+      });
+
+      if (allFieldsReady) {
+        const values = {};
+        for (const field of schema) {
+          values[field.key] = normalize(data[field.key]);
+        }
+        setInitialData(values);
+        initialDataInitializedRef.current = true; // Mark as initialized
       }
-      return current !== initVal
-    })
+    }
+  }, [block_id, data, schema, normalize]); // Add normalize and schema to dependencies
 
-    setReadyToCheck(changed)
-  }, [data])
+  // Function to determine if any data fields have changed from their initial state
+  const hasDataChanged = useCallback(() => {
+    if (!initialDataInitializedRef.current) return false; // Don't check if initial data isn't set yet
 
-  const handleFieldChange = (key, value) => {
-    onChange((prev) => {
-      const updated = { ...prev, [key]: value }
-
-      const changed = schema.some((field) => {
-        const newVal = normalize(updated[field.key])
-        const initVal = normalize(initialData[field.key])
-        return newVal !== initVal
-      })
-
-      setReadyToCheck(changed)
-      return updated
-    })
-  }
-
-  const hasDataChanged = () => {
     return schema.some((field) => {
-      const current = normalize(data?.[field.key])
-      const initVal = normalize(initialData[field.key])
-      return current !== initVal
-    })
-  }
+      const current = normalize(data?.[field.key]);
+      const initVal = normalize(initialData[field.key]);
+
+      // Optional: console log changes for debugging, but only when actually changed
+      if (current !== initVal) {
+        // console.log(`[🧨 Изменено поле]: ${field.key}`);
+        // console.log('  └ current:', current);
+        // console.log('  └ initial:', initVal);
+        return true;
+      }
+      return false;
+    });
+  }, [data, initialData, schema, normalize]); // Dependencies for useCallback
+
+  // This `showSaveButton` flag now directly reflects `hasDataChanged()`
+  const showSaveButton = hasDataChanged();
+
+  const handleFieldChange = useCallback((key, value) => {
+    onChange((prev) => {
+      const updated = { ...prev, [key]: value };
+      // `setReadyToCheck` is no longer needed here; `showSaveButton` will re-evaluate.
+      return updated;
+    });
+  }, [onChange]); // Add onChange to dependencies
 
   const handleSaveData = async (updatedData = data) => {
     try {
-      const filtered = {}
+      const filtered = {};
       for (const field of schema) {
-        filtered[field.key] = updatedData?.[field.key]
+        filtered[field.key] = updatedData?.[field.key];
       }
 
-      const url = `${import.meta.env.VITE_API_URL}/blocks/update-data/${site_name}/${slug}/${block_id}`
+      const url = `${import.meta.env.VITE_API_URL}/blocks/update-data/${site_name}/${slug}/${block_id}`;
 
       const res = await fetch(url, {
         method: 'PATCH',
@@ -94,53 +89,56 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
           Authorization: `Bearer ${localStorage.getItem('access_token')}`,
         },
         body: JSON.stringify({ data: filtered }),
-      })
+      });
 
       if (!res.ok) {
-        const errorText = await res.text()
-        throw new Error(errorText)
+        const errorText = await res.text();
+        throw new Error(errorText);
       }
 
-      await res.json()
+      await res.json();
 
-      setInitialData(filtered)
-      setReadyToCheck(false)
-      setShowSavedToast(true)
-      setResetButton(true)
+      // On successful save, update initialData to the newly saved state.
+      // This will cause `hasDataChanged` to return `false` until new edits are made.
+      setInitialData(filtered);
+      initialDataInitializedRef.current = true; // Confirm initialized after save
+
+      setShowSavedToast(true);
+      setResetButton(true);
 
       setTimeout(() => {
-        setShowSavedToast(false)
-        setResetButton(false)
-      }, 2000)
+        setShowSavedToast(false);
+        setResetButton(false);
+      }, 2000);
 
+      // Propagate the updated data to the global state if `setData` is provided
       if (setData) {
         setData((prev) => {
-          const updatedBlocks = { ...prev.blocks }
+          const updatedBlocks = { ...prev.blocks };
           const pageBlocks = updatedBlocks[slug]?.map((b) =>
             b.real_id === block_id ? { ...b, data: { ...filtered } } : b
-          )
+          );
           return {
             ...prev,
             blocks: {
               ...updatedBlocks,
               [slug]: pageBlocks,
             },
-          }
-        })
+          };
+        });
       }
     } catch (err) {
-      console.error('❌ PATCH упал:', err)
-      alert('Ошибка сохранения')
+      console.error('❌ PATCH упал:', err);
+      alert('Ошибка сохранения');
     }
-  }
-
-  const showSaveButton = readyToCheck
+  };
 
   return {
     handleFieldChange,
     handleSaveData,
     showSavedToast,
     resetButton,
-    showSaveButton,
-  }
+    showSaveButton, // Now directly derived from hasDataChanged
+    hasDataChanged, // Still export if parent needs to check directly
+  };
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
@@ -6,28 +6,27 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
   const [showSavedToast, setShowSavedToast] = useState(false)
   const [resetButton, setResetButton] = useState(false)
 
+  const normalize = (val) => (val !== undefined ? val : '')
+
   useEffect(() => {
     const values = {}
     for (const field of schema) {
-      values[field.key] =
-        data?.[field.key] !== undefined ? data[field.key] : field.default ?? ''
+      values[field.key] = normalize(data?.[field.key])
     }
 
     setInitialData(values)
-
-    const isChanged = schema.some(
-      (field) => data?.[field.key] !== values[field.key]
-    )
-    setReadyToCheck(isChanged)
+    setReadyToCheck(false)
   }, [block_id])
 
   const handleFieldChange = (key, value) => {
     onChange((prev) => {
       const updated = { ...prev, [key]: value }
 
-      const changed = schema.some(
-        (field) => updated[field.key] !== initialData[field.key]
-      )
+      const changed = schema.some((field) => {
+        const newVal = updated[field.key] !== undefined ? updated[field.key] : ''
+        const initVal = initialData[field.key] !== undefined ? initialData[field.key] : ''
+        return newVal !== initVal
+      })
       setReadyToCheck(changed)
 
       return updated
@@ -35,7 +34,11 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
   }
 
   const hasDataChanged = () => {
-    return schema.some((field) => data?.[field.key] !== initialData[field.key])
+    return schema.some((field) => {
+      const current = data?.[field.key] !== undefined ? data[field.key] : ''
+      const initVal = initialData[field.key] !== undefined ? initialData[field.key] : ''
+      return current !== initVal
+    })
   }
 
   const handleSaveData = async (updatedData = data) => {
@@ -104,10 +107,11 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
   }
 
   useEffect(() => {
-    console.log('🟡 Сравниваем data и initialData:', data, initialData)
-    const changed = schema.some(
-      (field) => data?.[field.key] !== initialData[field.key]
-    )
+    const changed = schema.some((field) => {
+      const current = data?.[field.key] !== undefined ? data[field.key] : ''
+      const initVal = initialData[field.key] !== undefined ? initialData[field.key] : ''
+      return current !== initVal
+    })
     setReadyToCheck(changed)
   }, [data])
 

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
@@ -5,6 +5,7 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
   const [readyToCheck, setReadyToCheck] = useState(false)
   const [showSavedToast, setShowSavedToast] = useState(false)
   const [resetButton, setResetButton] = useState(false)
+  const [justMounted, setJustMounted] = useState(true)
 
   const normalize = (val) => (val !== undefined ? val : '')
 
@@ -16,6 +17,7 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
 
     setInitialData(values)
     setReadyToCheck(false)
+    setJustMounted(true)
   }, [block_id])
 
   const handleFieldChange = (key, value) => {
@@ -23,8 +25,8 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
       const updated = { ...prev, [key]: value }
 
       const changed = schema.some((field) => {
-        const newVal = updated[field.key] !== undefined ? updated[field.key] : ''
-        const initVal = initialData[field.key] !== undefined ? initialData[field.key] : ''
+        const newVal = normalize(updated[field.key])
+        const initVal = normalize(initialData[field.key])
         return newVal !== initVal
       })
       setReadyToCheck(changed)
@@ -35,8 +37,8 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
 
   const hasDataChanged = () => {
     return schema.some((field) => {
-      const current = data?.[field.key] !== undefined ? data[field.key] : ''
-      const initVal = initialData[field.key] !== undefined ? initialData[field.key] : ''
+      const current = normalize(data?.[field.key])
+      const initVal = normalize(initialData[field.key])
       return current !== initVal
     })
   }
@@ -107,15 +109,20 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
   }
 
   useEffect(() => {
+    if (justMounted) {
+      setJustMounted(false)
+      return
+    }
+
     const changed = schema.some((field) => {
-      const current = data?.[field.key] !== undefined ? data[field.key] : ''
-      const initVal = initialData[field.key] !== undefined ? initialData[field.key] : ''
+      const current = normalize(data?.[field.key])
+      const initVal = normalize(initialData[field.key])
       return current !== initVal
     })
     setReadyToCheck(changed)
   }, [data])
 
-  const showSaveButton = readyToCheck && hasDataChanged()
+  const showSaveButton = readyToCheck
 
   return {
     handleFieldChange,

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockData.js
@@ -1,15 +1,18 @@
 import { useEffect, useState } from 'react'
 
 export function useBlockData({ schema, data, block_id, slug, site_name, setData, onChange }) {
-  const [initialData, setInitialData] = useState({})
+
+  const getValues = (source = {}) => {
+      values[field.key] = normalize(source[field.key])
+    return values
+  }
+  const [initialData, setInitialData] = useState(getValues(data))
   const [readyToCheck, setReadyToCheck] = useState(false)
   const [showSavedToast, setShowSavedToast] = useState(false)
   const [resetButton, setResetButton] = useState(false)
-  const [justMounted, setJustMounted] = useState(true)
-
-  const normalize = (val) => (val !== undefined ? val : '')
 
   useEffect(() => {
+    setInitialData(getValues(data))
     const values = {}
     for (const field of schema) {
       values[field.key] = normalize(data?.[field.key])
@@ -82,6 +85,10 @@ export function useBlockData({ schema, data, block_id, slug, site_name, setData,
       setReadyToCheck(false)
       setShowSavedToast(true)
       setResetButton(true)
+    if (!readyToCheck) {
+      setInitialData(getValues(data))
+    }
+
       setTimeout(() => {
         setShowSavedToast(false)
         setResetButton(false)

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockAppearance.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockAppearance.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+
 
 export default function BlockAppearance({
   schema,
@@ -6,22 +6,9 @@ export default function BlockAppearance({
   onChange,
   fieldTypes,
   onSaveAppearance,
-  showButton,
-  resetButton,
   uiDefaults = {},
 }) {
-  const [internalVisible, setInternalVisible] = useState(false)
-  const [isSaving, setIsSaving] = useState(false)
 
-  useEffect(() => {
-    if (resetButton) {
-      setInternalVisible(false)
-      return
-    }
-
-    if (showButton) setInternalVisible(true)
-    if (!settings?.custom_appearance) setInternalVisible(false)
-  }, [showButton, settings?.custom_appearance, resetButton])
 
   const renderField = (field) => {
     if (field.visible_if) {
@@ -46,29 +33,10 @@ export default function BlockAppearance({
     )
   }
 
-  const handleClick = async () => {
-    setIsSaving(true)
-    await onSaveAppearance?.(settings)
-    setIsSaving(false)
-  }
-
   return (
     <div className="pt-4 border-t mt-6 space-y-4">
       {schema.map(field => field.editable && renderField(field))}
 
-      {internalVisible && (
-        <div>
-          <button
-            onClick={handleClick}
-            disabled={isSaving}
-            className={`bg-blue-600 text-white px-4 py-2 rounded transition text-sm ${
-              isSaving ? 'opacity-50 cursor-not-allowed' : 'hover:bg-blue-700'
-            }`}
-          >
-            💾 Сохранить внешний вид блока
-          </button>
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- drop local save buttons in block editors
- introduce single floating save button
- clean up unused props and logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ac86fca38833185e92abf0b5c2af9