### PR TITLE
Refactor block appearance logic

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/AboutCompany.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/AboutCompany.jsx
@@ -1,33 +1,27 @@
 import React from 'react'
 
 export const AboutCompany = ({ settings = {}, data = {}, commonSettings = {} }) => {
-  const isCustom = settings?.custom_appearance === true
-
-  const source = isCustom
-    ? settings
-    : {
-        background_color: commonSettings.background?.base,
-        text_color: commonSettings.text?.primary,
-        subtle_text_color: commonSettings.text?.secondary,
-        padding_top: 48,
-        padding_bottom: 48,
-        title_font_size: 24,
-        desc_font_size: 16,
-        max_width: 768,
-        text_align: 'center',
-      }
-
   const {
-    background_color = '#FFFFFF',
-    text_color = '#212121',
-    subtle_text_color = '#6B7280',
-    padding_top = 48,
-    padding_bottom = 48,
-    title_font_size = 24,
-    desc_font_size = 16,
-    max_width = 768,
-    text_align = 'center',
-  } = source
+    background_color,
+    text_color,
+    subtle_text_color,
+    padding_top,
+    padding_bottom,
+    title_font_size,
+    desc_font_size,
+    max_width,
+    text_align,
+  } = settings
+
+  const bgColor = background_color ?? commonSettings.background?.base ?? '#FFFFFF'
+  const textColor = text_color ?? commonSettings.text?.primary ?? '#212121'
+  const subtleColor = subtle_text_color ?? commonSettings.text?.secondary ?? '#6B7280'
+  const paddingTop = padding_top ?? 48
+  const paddingBottom = padding_bottom ?? 48
+  const titleFont = title_font_size ?? 24
+  const descFont = desc_font_size ?? 16
+  const maxWidth = max_width ?? 768
+  const align = text_align ?? 'center'
 
   const title = data.title || 'О компании'
   const text = data.text || 'Мы доставляем горячую пиццу с любовью. Работаем с 10:00 до 23:00 каждый день.'
@@ -36,20 +30,20 @@ export const AboutCompany = ({ settings = {}, data = {}, commonSettings = {} }) 
     <div
       className="w-full px-4"
       style={{
-        backgroundColor: background_color,
-        paddingTop: padding_top,
-        paddingBottom: padding_bottom,
-        textAlign: text_align,
+        backgroundColor: bgColor,
+        paddingTop: paddingTop,
+        paddingBottom: paddingBottom,
+        textAlign: align,
       }}
     >
-      <div className="mx-auto" style={{ maxWidth: max_width }}>
+      <div className="mx-auto" style={{ maxWidth: maxWidth }}>
         <h2
           className="font-semibold mb-2"
-          style={{ color: text_color, fontSize: `${title_font_size}px` }}
+          style={{ color: textColor, fontSize: `${titleFont}px` }}
         >
           {title}
         </h2>
-        <p style={{ color: subtle_text_color, fontSize: `${desc_font_size}px` }}>{text}</p>
+        <p style={{ color: subtleColor, fontSize: `${descFont}px` }}>{text}</p>
       </div>
     </div>
   )

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/AboutCompanyPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/AboutCompanyPreview.jsx
@@ -11,26 +11,14 @@ export default function AboutCompanyPreview({ settings = {}, data = {}, commonSe
   useEffect(() => {
     if (!globalSiteData?.ui_schema) return
 
-    if (settings?.custom_appearance) {
-      const vars = {}
-      Object.entries(settings).forEach(([key, val]) => {
-        if (key.includes('color') || key.startsWith('bg_')) {
-          vars[`--${key.replace(/_/g, '-')}`] = val
-        }
-      })
-
-      const varsJson = JSON.stringify(vars)
-      const styleVarsJson = JSON.stringify(styleVars)
-
-      if (varsJson !== styleVarsJson) {
-        setStyleVars(vars)
+    applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+    const vars = {}
+    Object.entries(settings).forEach(([key, val]) => {
+      if (key.includes('color') || key.startsWith('bg_')) {
+        vars[`--${key.replace(/_/g, '-')}`] = val
       }
-    } else {
-      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
-      if (Object.keys(styleVars).length > 0) {
-        setStyleVars({})
-      }
-    }
+    })
+    setStyleVars(vars)
   }, [settings, globalSiteData?.ui_schema])
 
   return (

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
@@ -5,12 +5,14 @@ import { aboutDataSchema } from './aboutDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import TextItemsEditor from './ItemsEditor'
 import TextAppearance from './Appearance'
+import { Tabs, Tab } from '@/components/ui/tabs'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
 export default function TextEditor({ block, slug, onChange }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
+  const [activeTab, setActiveTab] = useState('data')
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
 
@@ -72,26 +74,36 @@ export default function TextEditor({ block, slug, onChange }) {
         </div>
       )}
 
-      <div className="text-sm text-gray-500 italic pl-1">
-        ⚙️ Настройка текстового блока: фон, цвета заголовка и описания
-      </div>
+      <Tabs value={activeTab} onChange={setActiveTab} className="mb-4">
+        <Tab value="data">Данные</Tab>
+        <Tab value="appearance">Дизайн</Tab>
+      </Tabs>
 
-      <TextItemsEditor
-        schema={aboutDataSchema}
-        data={dataState}
-        onTextChange={handleDataChange}
-        onSaveData={() => handleSaveData(dataState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'data' && (
+        <TextItemsEditor
+          schema={aboutDataSchema}
+          data={dataState}
+          onTextChange={handleDataChange}
+          onSaveData={() => handleSaveData(dataState)}
+          uiDefaults={uiDefaults}
+        />
+      )}
 
-      <TextAppearance
-        schema={aboutSchema}
-        settings={settingsState}
-        onChange={handleFieldChange}
-        fieldTypes={fieldTypes}
-        onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'appearance' && (
+        <>
+          <div className="text-sm text-gray-500 italic pl-1">
+            ⚙️ Настройка текстового блока: фон, цвета заголовка и описания
+          </div>
+          <TextAppearance
+            schema={aboutSchema}
+            settings={settingsState}
+            onChange={handleFieldChange}
+            fieldTypes={fieldTypes}
+            onSaveAppearance={() => handleSaveAppearance(settingsState)}
+            uiDefaults={uiDefaults}
+          />
+        </>
+      )}
 
       {(showDataButton || showSaveButton) && (
         <button

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/aboutSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/aboutSchema.js
@@ -1,18 +1,11 @@
 export const aboutSchema = [
-  {
-    key: 'custom_appearance',
-    label: 'Изменить внешний вид блока (фон и цвета)',
-    type: 'boolean',
-    default: false,
-    editable: true
-  },
-  {
+    {
     key: 'background_color',
     label: 'Фон блока',
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'text_color',
@@ -20,7 +13,7 @@ export const aboutSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'subtle_text_color',
@@ -28,7 +21,7 @@ export const aboutSchema = [
     type: 'color',
     default: '#6B7280',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'padding_top',
@@ -36,7 +29,7 @@ export const aboutSchema = [
     type: 'number',
     default: 48,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'padding_bottom',
@@ -44,7 +37,7 @@ export const aboutSchema = [
     type: 'number',
     default: 48,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'title_font_size',
@@ -52,7 +45,7 @@ export const aboutSchema = [
     type: 'fontsize',
     default: 24,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'desc_font_size',
@@ -60,7 +53,7 @@ export const aboutSchema = [
     type: 'fontsize',
     default: 16,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'max_width',
@@ -68,7 +61,7 @@ export const aboutSchema = [
     type: 'number',
     default: 768,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'text_align',
@@ -77,6 +70,6 @@ export const aboutSchema = [
     options: ['left', 'center', 'right'],
     default: 'center',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/BannerPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/BannerPreview.jsx
@@ -11,26 +11,14 @@ export default function BannerPreview({ settings = {}, data = {}, commonSettings
   useEffect(() => {
     if (!globalSiteData?.ui_schema) return
 
-    if (settings?.custom_appearance) {
-      const vars = {}
-      Object.entries(settings).forEach(([key, val]) => {
-        if (key.includes('color') || key.startsWith('bg_')) {
-          vars[`--${key.replace(/_/g, '-')}`] = val
-        }
-      })
-
-      const varsJson = JSON.stringify(vars)
-      const styleVarsJson = JSON.stringify(styleVars)
-
-      if (varsJson !== styleVarsJson) {
-        setStyleVars(vars)
+    applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+    const vars = {}
+    Object.entries(settings).forEach(([key, val]) => {
+      if (key.includes('color') || key.startsWith('bg_')) {
+        vars[`--${key.replace(/_/g, '-')}`] = val
       }
-    } else {
-      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
-      if (Object.keys(styleVars).length > 0) {
-        setStyleVars({})
-      }
-    }
+    })
+    setStyleVars(vars)
   }, [settings, globalSiteData?.ui_schema])
 
   return (

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
@@ -83,7 +83,6 @@ export default function BannerEditor({ block, slug, onChange }) {
 
   console.log('🧪 showDataButton:', showDataButton)
   console.log('🧪 showAppearanceButton:', showAppearanceButton)
-  console.log('🧪 settingsState.custom_appearance:', settingsState?.custom_appearance)
   console.log('🧪 dataState:', dataState)
 
   return (

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
@@ -7,6 +7,7 @@ import { fieldTypes } from '@/components/fields/fieldTypes'
 import BannerItemsEditor from './ItemsEditor'
 import BannerAppearance from './Appearance'
 import BannerPreview from './BannerPreview'
+import { Tabs, Tab } from '@/components/ui/tabs'
 
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
@@ -14,7 +15,7 @@ import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 export default function BannerEditor({ block, slug, onChange }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
-
+  const [activeTab, setActiveTab] = useState('data')
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
   const [canShow, setCanShow] = useState(false)
@@ -93,25 +94,35 @@ export default function BannerEditor({ block, slug, onChange }) {
         </div>
       )}
 
-      <BannerItemsEditor
-        schema={bannerDataSchema}
-        data={dataState}
-        onTextChange={handleTextFieldChange}
-        onSaveData={() => handleSaveData(dataState)}
-      />
+      <Tabs value={activeTab} onChange={setActiveTab} className="mb-4">
+        <Tab value="data">Данные</Tab>
+        <Tab value="appearance">Дизайн</Tab>
+      </Tabs>
 
-      <div className="text-sm text-gray-500 italic pl-1 pt-4 border-t">
-        🎨 Редактирование внешнего вида блока
-      </div>
+      {activeTab === 'data' && (
+        <BannerItemsEditor
+          schema={bannerDataSchema}
+          data={dataState}
+          onTextChange={handleTextFieldChange}
+          onSaveData={() => handleSaveData(dataState)}
+        />
+      )}
 
-      <BannerAppearance
-        schema={bannerSchema}
-        settings={settingsState}
-        onChange={handleFieldChange}
-        fieldTypes={fieldTypes}
-        onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'appearance' && (
+        <>
+          <div className="text-sm text-gray-500 italic pl-1 pt-4 border-t">
+            🎨 Редактирование внешнего вида блока
+          </div>
+          <BannerAppearance
+            schema={bannerSchema}
+            settings={settingsState}
+            onChange={handleFieldChange}
+            fieldTypes={fieldTypes}
+            onSaveAppearance={() => handleSaveAppearance(settingsState)}
+            uiDefaults={uiDefaults}
+          />
+        </>
+      )}
 
       {canShow && (
         <button

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/TopBanner.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/TopBanner.jsx
@@ -2,13 +2,10 @@ import { ArrowRight } from 'lucide-react'
 import pizzaImg from '/images/1.png'
 
 export const TopBanner = ({ settings = {}, data = {}, commonSettings = {} }) => {
-  const isCustom = settings?.custom_appearance === true
-  const source = isCustom ? settings : commonSettings
-
-  const reverse = source?.reverse_layout === true
-  const layout = source?.layout_variant || 'wide'
-  const hoverEffect = source?.hover_effect !== false
-  const imgStyle = source?.img_style || 'default'
+  const reverse = (settings.reverse_layout ?? commonSettings.reverse_layout) === true
+  const layout = settings.layout_variant ?? commonSettings.layout_variant ?? 'wide'
+  const hoverEffect = (settings.hover_effect ?? commonSettings.hover_effect ?? true) !== false
+  const imgStyle = settings.img_style ?? commonSettings.img_style ?? 'default'
 
   const titleText = data?.title_text || 'Дарим подарки'
   const subtitleText = data?.subtitle_text || 'Выбирай на свой вкус из нашего ассортимента!'
@@ -23,22 +20,17 @@ export const TopBanner = ({ settings = {}, data = {}, commonSettings = {} }) => 
     : pizzaImg
 
   const getGradient = () => {
-    if (isCustom) {
-      const from = source?.bg_gradient_from || '#1976D2'
-      const to = source?.bg_gradient_to || '#90CAF9'
-      return `linear-gradient(to right, ${from}, ${to})`
-    }
-    const from = source?.background?.gradient_from || '#1976D2'
-    const to = source?.background?.gradient_to || '#90CAF9'
+    const from = settings.bg_gradient_from ?? commonSettings.background?.gradient_from ?? '#1976D2'
+    const to = settings.bg_gradient_to ?? commonSettings.background?.gradient_to ?? '#90CAF9'
     return `linear-gradient(to right, ${from}, ${to})`
   }
 
   const style = {
     backgroundImage: getGradient(),
-    '--text-color': isCustom ? source?.text_color : source?.text?.primary || '#212121',
-    '--button-bg-color': isCustom ? source?.button_bg_color : source?.button?.bg || '#1976D2',
-    '--button-text-color': isCustom ? source?.button_text_color : source?.button?.text || '#FFFFFF',
-    '--button-hover-color': isCustom ? source?.button_hover_color : source?.button?.hover_bg || '#1259A8',
+    '--text-color': settings.text_color ?? commonSettings.text?.primary ?? '#212121',
+    '--button-bg-color': settings.button_bg_color ?? commonSettings.button?.bg ?? '#1976D2',
+    '--button-text-color': settings.button_text_color ?? commonSettings.button?.text ?? '#FFFFFF',
+    '--button-hover-color': settings.button_hover_color ?? commonSettings.button?.hover_bg ?? '#1259A8',
   }
 
   const imageClass = `relative z-10 w-[280px] lg:w-[320px] object-contain drop-shadow-[0_8px_24px_rgba(0,0,0,0.25)] transition duration-300 ${hoverEffect ? 'hover:scale-110' : ''} ${imgStyle === 'glow' ? 'animate-pulse-slow' : ''}`

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/bannerSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/bannerSchema.js
@@ -1,18 +1,11 @@
 export const bannerSchema = [
-  {
-    key: 'custom_appearance',
-    label: 'Изменить внешний вид блока (фон, кнопка, текст)',
-    type: 'boolean',
-    default: false,
-    editable: true
-  },
-  {
+    {
     key: 'bg_gradient_from',
     label: 'Цвет градиента (начало)',
     type: 'color',
     default: '#1976D2',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'bg_gradient_to',
@@ -20,7 +13,7 @@ export const bannerSchema = [
     type: 'color',
     default: '#90CAF9',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'text_color',
@@ -28,7 +21,7 @@ export const bannerSchema = [
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'button_bg_color',
@@ -36,7 +29,7 @@ export const bannerSchema = [
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'button_text_color',
@@ -44,7 +37,7 @@ export const bannerSchema = [
     type: 'color',
     default: '#1976D2',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'button_hover_color',
@@ -52,7 +45,7 @@ export const bannerSchema = [
     type: 'color',
     default: '#F3F4F6',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
 
   // 🔽 Новые переменные
@@ -63,7 +56,7 @@ export const bannerSchema = [
     options: ['left', 'center', 'right'],
     default: 'left',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'img_style',
@@ -72,7 +65,7 @@ export const bannerSchema = [
     options: ['default', 'float', 'glow'],
     default: 'default',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'hover_effect',
@@ -80,7 +73,7 @@ export const bannerSchema = [
     type: 'boolean',
     default: true,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'layout_variant',
@@ -89,7 +82,7 @@ export const bannerSchema = [
     options: ['wide', 'narrow'],
     default: 'wide',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'reverse_layout',
@@ -97,6 +90,6 @@ export const bannerSchema = [
     type: 'boolean',
     default: false,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Delivery.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Delivery.jsx
@@ -1,34 +1,18 @@
 import mapImage from '/images/7.webp'
 
 export const Delivery = ({ settings = {}, data = {}, commonSettings = {} }) => {
-  const isCustom = settings?.custom_appearance === true
-  const source = isCustom
-    ? settings
-    : {
-        background_color: commonSettings.background?.base,
-        text_color: commonSettings.text?.primary,
-        desc_color: commonSettings.text?.secondary,
-        icon_color: commonSettings.icon?.default,
-        card_bg_color: commonSettings.background?.card,
-        card_shadow: commonSettings.shadow?.default || 'medium',
-        map_border_radius: 16,
-        map_shadow: 'medium',
-        section_spacing_top: 48,
-        section_spacing_bottom: 48,
-        font_size_title: 20,
-        font_size_desc: 14,
-      }
-
-  const bg = source?.background_color || '#FFFFFF'
-  const titleColor = source?.text_color || '#212121'
-  const descColor = source?.desc_color || '#666666'
-  const accentColor = source?.icon_color || '#1976D2'
-  const cardBg = source?.card_bg_color || '#FFFFFF'
-  const mapBorderRadius = source?.map_border_radius || 16
-  const sectionPaddingTop = source?.section_spacing_top || 48
-  const sectionPaddingBottom = source?.section_spacing_bottom || 48
-  const fontSizeTitle = source?.font_size_title || 20
-  const fontSizeDesc = source?.font_size_desc || 14
+  const bg = settings.background_color ?? commonSettings.background?.base ?? '#FFFFFF'
+  const titleColor = settings.text_color ?? commonSettings.text?.primary ?? '#212121'
+  const descColor = settings.desc_color ?? commonSettings.text?.secondary ?? '#666666'
+  const accentColor = settings.icon_color ?? commonSettings.icon?.default ?? '#1976D2'
+  const cardBg = settings.card_bg_color ?? commonSettings.background?.card ?? '#FFFFFF'
+  const mapBorderRadius = settings.map_border_radius ?? 16
+  const sectionPaddingTop = settings.section_spacing_top ?? 48
+  const sectionPaddingBottom = settings.section_spacing_bottom ?? 48
+  const fontSizeTitle = settings.font_size_title ?? 20
+  const fontSizeDesc = settings.font_size_desc ?? 14
+  const cardShadow = settings.card_shadow ?? commonSettings.shadow?.default ?? 'medium'
+  const mapShadow = settings.map_shadow ?? 'medium'
 
   const shadowMap = {
     none: 'shadow-none',
@@ -36,8 +20,8 @@ export const Delivery = ({ settings = {}, data = {}, commonSettings = {} }) => {
     medium: 'shadow',
     high: 'shadow-lg',
   }
-  const cardShadowClass = shadowMap[source?.card_shadow] || 'shadow'
-  const mapShadowClass = shadowMap[source?.map_shadow] || 'shadow'
+  const cardShadowClass = shadowMap[cardShadow] || 'shadow'
+  const mapShadowClass = shadowMap[mapShadow] || 'shadow'
 
   const sectionTitle = data.section_title || 'Доставка и оплата в Анапе'
   const bannerTitle = data.banner_title || '60 МИНУТ ИЛИ ПИЦЦА БЕСПЛАТНО'

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/DeliveryPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/DeliveryPreview.jsx
@@ -11,27 +11,20 @@ export default function DeliveryPreview({ settings = {}, data = {}, commonSettin
   useEffect(() => {
     if (!globalSiteData?.ui_schema) return
 
-    if (settings?.custom_appearance) {
-      const vars = {}
-      Object.entries(settings).forEach(([key, val]) => {
-        if (
-          key.includes('color') ||
-          key.includes('shadow') ||
-          key.includes('font') ||
-          key.includes('spacing') ||
-          key.includes('radius')
-        ) {
-          vars[`--${key.replace(/_/g, '-')}`] = val
-        }
-      })
-
-      const varsJson = JSON.stringify(vars)
-      const styleVarsJson = JSON.stringify(styleVars)
-      if (varsJson !== styleVarsJson) setStyleVars(vars)
-    } else {
-      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
-      if (Object.keys(styleVars).length > 0) setStyleVars({})
-    }
+    applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+    const vars = {}
+    Object.entries(settings).forEach(([key, val]) => {
+      if (
+        key.includes('color') ||
+        key.includes('shadow') ||
+        key.includes('font') ||
+        key.includes('spacing') ||
+        key.includes('radius')
+      ) {
+        vars[`--${key.replace(/_/g, '-')}`] = val
+      }
+    })
+    setStyleVars(vars)
   }, [settings, globalSiteData?.ui_schema])
 
   return (

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
@@ -5,13 +5,14 @@ import { deliveryDataSchema } from './deliveryDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import DeliveryItemsEditor from './ItemsEditor'
 import DeliveryAppearance from './Appearance'
+import { Tabs, Tab } from '@/components/ui/tabs'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
 export default function DeliveryEditor({ block, slug, onChange }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
-
+  const [activeTab, setActiveTab] = useState('data')
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
 
@@ -72,26 +73,36 @@ export default function DeliveryEditor({ block, slug, onChange }) {
         </div>
       )}
 
-      <DeliveryItemsEditor
-        schema={deliveryDataSchema}
-        data={dataState}
-        onTextChange={handleTextFieldChange}
-        onSaveData={() => handleSaveData(dataState)}
-        uiDefaults={uiDefaults}
-      />
+      <Tabs value={activeTab} onChange={setActiveTab} className="mb-4">
+        <Tab value="data">Данные</Tab>
+        <Tab value="appearance">Дизайн</Tab>
+      </Tabs>
 
-      <div className="text-sm text-gray-500 italic pl-1">
-        ⚙️ Настройка блока доставки: фон, карточки, тени, цвета текста
-      </div>
+      {activeTab === 'data' && (
+        <DeliveryItemsEditor
+          schema={deliveryDataSchema}
+          data={dataState}
+          onTextChange={handleTextFieldChange}
+          onSaveData={() => handleSaveData(dataState)}
+          uiDefaults={uiDefaults}
+        />
+      )}
 
-      <DeliveryAppearance
-        schema={deliverySchema}
-        settings={settingsState}
-        onChange={handleFieldChange}
-        fieldTypes={fieldTypes}
-        onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'appearance' && (
+        <>
+          <div className="text-sm text-gray-500 italic pl-1">
+            ⚙️ Настройка блока доставки: фон, карточки, тени, цвета текста
+          </div>
+          <DeliveryAppearance
+            schema={deliverySchema}
+            settings={settingsState}
+            onChange={handleFieldChange}
+            fieldTypes={fieldTypes}
+            onSaveAppearance={() => handleSaveAppearance(settingsState)}
+            uiDefaults={uiDefaults}
+          />
+        </>
+      )}
 
       {(showDataButton || showAppearanceButton) && (
         <button

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/deliverySchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/deliverySchema.js
@@ -1,18 +1,11 @@
 export const deliverySchema = [
-  {
-    key: 'custom_appearance',
-    label: 'Изменить внешний вид блока (фон, карточки, иконки)',
-    type: 'boolean',
-    default: false,
-    editable: true
-  },
-  {
+    {
     key: 'background_color',
     label: 'Фон секции',
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_bg_color',
@@ -20,7 +13,7 @@ export const deliverySchema = [
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_shadow',
@@ -29,7 +22,7 @@ export const deliverySchema = [
     options: ['none', 'low', 'medium', 'high'],
     default: 'medium',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'text_color',
@@ -37,7 +30,7 @@ export const deliverySchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'desc_color',
@@ -45,7 +38,7 @@ export const deliverySchema = [
     type: 'color',
     default: '#6B7280',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'icon_color',
@@ -53,7 +46,7 @@ export const deliverySchema = [
     type: 'color',
     default: '#F97316',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'map_border_radius',
@@ -61,7 +54,7 @@ export const deliverySchema = [
     type: 'number',
     default: 16,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'map_shadow',
@@ -70,7 +63,7 @@ export const deliverySchema = [
     options: ['none', 'low', 'medium', 'high'],
     default: 'medium',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'section_spacing_top',
@@ -78,7 +71,7 @@ export const deliverySchema = [
     type: 'number',
     default: 48,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'section_spacing_bottom',
@@ -86,7 +79,7 @@ export const deliverySchema = [
     type: 'number',
     default: 48,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size_title',
@@ -94,7 +87,7 @@ export const deliverySchema = [
     type: 'fontsize',
     default: 24,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size_desc',
@@ -102,6 +95,6 @@ export const deliverySchema = [
     type: 'fontsize',
     default: 14,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
@@ -5,13 +5,14 @@ import { createFooterDataSchema } from './footerDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import FooterItemsEditor from './ItemsEditor'
 import FooterAppearance from './Appearance'
+import { Tabs, Tab } from '@/components/ui/tabs'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
 export default function FooterEditor({ block, data, onChange, slug }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
-
+  const [activeTab, setActiveTab] = useState('data')
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
 
@@ -72,26 +73,36 @@ export default function FooterEditor({ block, data, onChange, slug }) {
         </div>
       )}
 
-      <div className="text-sm text-gray-500 italic pl-1">
-        ⚙️ Настройка подвала: цвета фона, текста и линии
-      </div>
+      <Tabs value={activeTab} onChange={setActiveTab} className="mb-4">
+        <Tab value="data">Данные</Tab>
+        <Tab value="appearance">Дизайн</Tab>
+      </Tabs>
 
-      <FooterItemsEditor
-        schema={createFooterDataSchema(settingsState?.show_social_icons)}
-        data={dataState}
-        onTextChange={handleDataChange}
-        onSaveData={() => handleSaveData(dataState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'data' && (
+        <FooterItemsEditor
+          schema={createFooterDataSchema(settingsState?.show_social_icons)}
+          data={dataState}
+          onTextChange={handleDataChange}
+          onSaveData={() => handleSaveData(dataState)}
+          uiDefaults={uiDefaults}
+        />
+      )}
 
-      <FooterAppearance
-        schema={footerSchema}
-        settings={settingsState}
-        onChange={handleFieldChange}
-        fieldTypes={fieldTypes}
-        onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'appearance' && (
+        <>
+          <div className="text-sm text-gray-500 italic pl-1">
+            ⚙️ Настройка подвала: цвета фона, текста и линии
+          </div>
+          <FooterAppearance
+            schema={footerSchema}
+            settings={settingsState}
+            onChange={handleFieldChange}
+            fieldTypes={fieldTypes}
+            onSaveAppearance={() => handleSaveAppearance(settingsState)}
+            uiDefaults={uiDefaults}
+          />
+        </>
+      )}
 
       {(showDataButton || showSaveButton) && (
         <button

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Footer.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Footer.jsx
@@ -24,29 +24,6 @@ export const Footer = ({ settings = {}, commonSettings = {}, data = {} }) => {
   }
   const show_payment_icons = settings.show_payment_icons ?? false
 
-  const {
-    background_color = '#FFFFFF',
-    text_color = '#212121',
-    border_color = 'rgba(0,0,0,0.1)',
-    font_family = 'inherit',
-    font_size_base = 14,
-    transition_duration = '0.3s',
-    icon_color = '#6B7280',
-    icon_color_hover = '#374151',
-    alignment = 'spread',
-    section_spacing_top = 48,
-    section_spacing_bottom = 24,
-    show_sections = { about: true, contacts: true, socials: true },
-    show_social_icons = {
-      facebook: true,
-      instagram: true,
-      vk: true,
-      youtube: true,
-      telegram: true,
-      twitter: true,
-    },
-
-
   const alignmentClass = {
     left: 'items-start text-left',
     center: 'items-center text-center',

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Footer.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Footer.jsx
@@ -2,37 +2,27 @@ import { Facebook, Instagram, Youtube, Twitter, Phone, Mail } from 'lucide-react
 import { SiVk, SiTelegram } from 'react-icons/si'
 
 export const Footer = ({ settings = {}, commonSettings = {}, data = {} }) => {
-  const isCustom = settings?.custom_appearance === true
-
-  const source = isCustom
-    ? settings
-    : {
-        background_color: commonSettings.background?.muted,
-        text_color: commonSettings.text?.primary,
-        border_color: commonSettings.background?.surface,
-        font_family: commonSettings.typography?.font_family,
-        font_size_base: 14,
-        transition_duration: `${commonSettings.transition?.duration || 0.3}s`,
-        icon_color: commonSettings.icon?.default,
-        icon_color_hover: commonSettings.icon?.hover,
-        alignment: 'spread',
-        section_spacing_top: 48,
-        section_spacing_bottom: 24,
-        show_sections: {
-          about: true,
-          contacts: true,
-          socials: true,
-        },
-        show_social_icons: {
-          facebook: true,
-          instagram: true,
-          vk: true,
-          youtube: true,
-          telegram: true,
-          twitter: true,
-        },
-        show_payment_icons: false,
-      }
+  const background_color = settings.background_color ?? commonSettings.background?.muted ?? '#FFFFFF'
+  const text_color = settings.text_color ?? commonSettings.text?.primary ?? '#212121'
+  const border_color = settings.border_color ?? commonSettings.background?.surface ?? 'rgba(0,0,0,0.1)'
+  const font_family = settings.font_family ?? commonSettings.typography?.font_family ?? 'inherit'
+  const font_size_base = settings.font_size_base ?? 14
+  const transition_duration = settings.transition_duration ?? `${commonSettings.transition?.duration || 0.3}s`
+  const icon_color = settings.icon_color ?? commonSettings.icon?.default ?? '#6B7280'
+  const icon_color_hover = settings.icon_color_hover ?? commonSettings.icon?.hover ?? '#374151'
+  const alignment = settings.alignment ?? 'spread'
+  const section_spacing_top = settings.section_spacing_top ?? 48
+  const section_spacing_bottom = settings.section_spacing_bottom ?? 24
+  const show_sections = settings.show_sections ?? { about: true, contacts: true, socials: true }
+  const show_social_icons = settings.show_social_icons ?? {
+    facebook: true,
+    instagram: true,
+    vk: true,
+    youtube: true,
+    telegram: true,
+    twitter: true,
+  }
+  const show_payment_icons = settings.show_payment_icons ?? false
 
   const {
     background_color = '#FFFFFF',
@@ -55,7 +45,7 @@ export const Footer = ({ settings = {}, commonSettings = {}, data = {} }) => {
       telegram: true,
       twitter: true,
     },
-  } = source
+
 
   const alignmentClass = {
     left: 'items-start text-left',

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/FooterPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/FooterPreview.jsx
@@ -11,26 +11,14 @@ export default function FooterPreview({ settings = {}, data = {}, commonSettings
   useEffect(() => {
     if (!globalSiteData?.ui_schema) return
 
-    if (settings?.custom_appearance) {
-      const vars = {}
-      Object.entries(settings).forEach(([key, val]) => {
-        if (key.includes('color') || key.startsWith('bg_')) {
-          vars[`--${key.replace(/_/g, '-')}`] = val
-        }
-      })
-
-      const varsJson = JSON.stringify(vars)
-      const styleVarsJson = JSON.stringify(styleVars)
-
-      if (varsJson !== styleVarsJson) {
-        setStyleVars(vars)
+    applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+    const vars = {}
+    Object.entries(settings).forEach(([key, val]) => {
+      if (key.includes('color') || key.startsWith('bg_')) {
+        vars[`--${key.replace(/_/g, '-')}`] = val
       }
-    } else {
-      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
-      if (Object.keys(styleVars).length > 0) {
-        setStyleVars({})
-      }
-    }
+    })
+    setStyleVars(vars)
   }, [settings, globalSiteData?.ui_schema])
 
   return (

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/footerSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/footerSchema.js
@@ -1,18 +1,11 @@
 export const footerSchema = [
-  {
-    key: 'custom_appearance',
-    label: 'Изменить внешний вид блока (фон и цвета)',
-    type: 'checkbox',
-    default: false,
-    editable: true
-  },
-  {
+    {
     key: 'background_color',
     label: 'Фон подвала',
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'text_color',
@@ -20,7 +13,7 @@ export const footerSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'border_color',
@@ -28,7 +21,7 @@ export const footerSchema = [
     type: 'color',
     default: '#E5E7EB',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size_base',
@@ -36,7 +29,7 @@ export const footerSchema = [
     type: 'fontsize',
     default: 14,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'icon_color',
@@ -44,7 +37,7 @@ export const footerSchema = [
     type: 'color',
     default: '#6B7280',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'icon_color_hover',
@@ -52,7 +45,7 @@ export const footerSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'section_spacing_top',
@@ -60,7 +53,7 @@ export const footerSchema = [
     type: 'number',
     default: 48,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'section_spacing_bottom',
@@ -68,7 +61,7 @@ export const footerSchema = [
     type: 'number',
     default: 48,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'alignment',
@@ -77,7 +70,7 @@ export const footerSchema = [
     options: ['left', 'center', 'spread'],
     default: 'spread',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'show_sections',
@@ -94,7 +87,7 @@ export const footerSchema = [
       socials: true
     },
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'show_social_icons',
@@ -117,7 +110,7 @@ export const footerSchema = [
       twitter: true,
     },
     editable: true,
-    visible_if: { custom_appearance: true },
+    visible: true,
   },
   {
     key: 'show_payment_icons',
@@ -125,6 +118,6 @@ export const footerSchema = [
     type: 'boolean',
     default: true,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Appearance.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Appearance.jsx
@@ -10,10 +10,7 @@ export default function NavigationAppearance({
 }) {
 
   const renderField = (field) => {
-    if (field.visible_if) {
-      const [[depKey, depVal]] = Object.entries(field.visible_if)
-      if (settings?.[depKey] !== depVal) return null
-    }
+    if (field.visible === false) return null
 
     const FieldComponent = fieldTypes[field.type] || fieldTypes.text
     const value =

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Header.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Header.jsx
@@ -7,26 +7,14 @@ export const Header = ({ settings = {}, data = {}, commonSettings = {}, navigati
   const [mobileOpen, setMobileOpen] = useState(false)
   const visibleItems = navigation?.filter(item => item.visible) || []
 
-  const isCustom = settings?.custom_appearance === true
-  const source = isCustom ? settings : {
-    text_color: commonSettings.text?.primary,
-    primary_color: commonSettings.text?.accent,
-    secondary_color: commonSettings.text?.secondary,
-    rating_color: commonSettings.icon?.rating,
-    button_bg_color: commonSettings.button?.bg,
-    button_text_color: commonSettings.button?.text,
-    button_hover_color: commonSettings.button?.hover_bg,
-    background_color: commonSettings.background?.base,
-  }
-
-  const textColor = source?.text_color || '#212121'
-  const primaryColor = source?.primary_color || '#1976D2'
-  const secondaryColor = source?.secondary_color || '#90CAF9'
-  const ratingColor = source?.rating_color || '#FACC15'
-  const buttonBg = source?.button_bg_color || '#1976D2'
-  const buttonText = source?.button_text_color || '#FFFFFF'
-  const buttonHover = source?.button_hover_color || '#1565C0'
-  const bgColor = source?.background_color || '#FFFFFF'
+  const textColor = settings.text_color ?? commonSettings.text?.primary ?? '#212121'
+  const primaryColor = settings.primary_color ?? commonSettings.text?.accent ?? '#1976D2'
+  const secondaryColor = settings.secondary_color ?? commonSettings.text?.secondary ?? '#90CAF9'
+  const ratingColor = settings.rating_color ?? commonSettings.icon?.rating ?? '#FACC15'
+  const buttonBg = settings.button_bg_color ?? commonSettings.button?.bg ?? '#1976D2'
+  const buttonText = settings.button_text_color ?? commonSettings.button?.text ?? '#FFFFFF'
+  const buttonHover = settings.button_hover_color ?? commonSettings.button?.hover_bg ?? '#1565C0'
+  const bgColor = settings.background_color ?? commonSettings.background?.base ?? '#FFFFFF'
 
   const rawLogoPath = data.logo_url || '/images/logo.webp'
   const baseUrl = import.meta.env.VITE_LIBRARY_ASSETS_URL || ''

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/HeaderPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/HeaderPreview.jsx
@@ -11,26 +11,14 @@ export default function HeaderPreview({ settings = {}, data = {}, commonSettings
   useEffect(() => {
     if (!globalSiteData?.ui_schema) return
 
-    if (settings?.custom_appearance) {
-      const vars = {}
-      Object.entries(settings).forEach(([key, val]) => {
-        if (key.includes('color') || key.startsWith('bg_')) {
-          vars[`--${key.replace(/_/g, '-')}`] = val
-        }
-      })
-
-      const varsJson = JSON.stringify(vars)
-      const styleVarsJson = JSON.stringify(styleVars)
-
-      if (varsJson !== styleVarsJson) {
-        setStyleVars(vars)
+    applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+    const vars = {}
+    Object.entries(settings).forEach(([key, val]) => {
+      if (key.includes('color') || key.startsWith('bg_')) {
+        vars[`--${key.replace(/_/g, '-')}`] = val
       }
-    } else {
-      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
-      if (Object.keys(styleVars).length > 0) {
-        setStyleVars({})
-      }
-    }
+    })
+    setStyleVars(vars)
   }, [settings, globalSiteData?.ui_schema])
 
   return (

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/headerSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/headerSchema.js
@@ -1,12 +1,5 @@
 export const headerSchema = [
-  {
-    key: "custom_appearance",
-    label: "Изменить внешний вид блока (цвета, кнопки и фон)",
-    type: "boolean",
-    default: false,
-    editable: true
-  },
-
+  
   // 🎨 Цвета
   {
     key: "background_color",
@@ -14,7 +7,7 @@ export const headerSchema = [
     type: "color",
     default: "#FFFFFF",
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: "text_color",
@@ -22,7 +15,7 @@ export const headerSchema = [
     type: "color",
     default: "#212121",
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: "secondary_color",
@@ -30,7 +23,7 @@ export const headerSchema = [
     type: "color",
     default: "#6B7280",
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: "primary_color",
@@ -38,7 +31,7 @@ export const headerSchema = [
     type: "color",
     default: "#1976D2",
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: "button_bg_color",
@@ -46,7 +39,7 @@ export const headerSchema = [
     type: "color",
     default: "#F3F4F6",
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: "button_text_color",
@@ -54,7 +47,7 @@ export const headerSchema = [
     type: "color",
     default: "#000000",
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: "button_hover_color",
@@ -62,7 +55,7 @@ export const headerSchema = [
     type: "color",
     default: "#E5E7EB",
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: "rating_color",
@@ -70,7 +63,7 @@ export const headerSchema = [
     type: "color",
     default: "#FACC15",
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
 
   // 👁️ Видимость блоков
@@ -80,7 +73,7 @@ export const headerSchema = [
     type: "boolean",
     default: true,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: "show_bonus_button",
@@ -88,7 +81,7 @@ export const headerSchema = [
     type: "boolean",
     default: true,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: "show_rating",
@@ -96,7 +89,7 @@ export const headerSchema = [
     type: "boolean",
     default: true,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
 
   // 🎯 Выравнивание
@@ -107,7 +100,7 @@ export const headerSchema = [
     options: ["left", "center"],
     default: "left",
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
 
   // 📐 Отступы
@@ -117,7 +110,7 @@ export const headerSchema = [
     type: "number",
     default: 16,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: "padding_y",
@@ -125,6 +118,6 @@ export const headerSchema = [
     type: "number",
     default: 12,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/Editor.jsx
@@ -4,11 +4,13 @@ import { tabsSchema } from './tabsSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import TabsItemsEditor from './ItemsEditor'
 import TabsAppearance from './Appearance'
+import { Tabs, Tab } from '@/components/ui/tabs'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 
 export default function TabsEditor({ block, data, onChange, slug }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
+  const [activeTab, setActiveTab] = useState('data')
   const [showToast, setShowToast] = useState(false)
 
   const {
@@ -39,27 +41,37 @@ export default function TabsEditor({ block, data, onChange, slug }) {
         <div className="text-green-600 text-sm font-medium">✅ Внешний вид сохранён</div>
       )}
 
-      <div className="text-sm text-gray-500 italic pl-1">
-        ⚙️ Настройка фона и цвета кнопок вкладок
-      </div>
+      <Tabs value={activeTab} onChange={setActiveTab} className="mb-4">
+        <Tab value="data">Данные</Tab>
+        <Tab value="appearance">Дизайн</Tab>
+      </Tabs>
 
-      <TabsItemsEditor
-        settings={data}
-        siteName={site_name}
-        siteData={siteData}
-        setData={setData}
-        onChange={onChange}
-        setShowToast={setShowToast}
-      />
+      {activeTab === 'data' && (
+        <TabsItemsEditor
+          settings={data}
+          siteName={site_name}
+          siteData={siteData}
+          setData={setData}
+          onChange={onChange}
+          setShowToast={setShowToast}
+        />
+      )}
 
-      <TabsAppearance
-        schema={tabsSchema}
-        settings={data}
-        onChange={handleFieldChange}
-        fieldTypes={fieldTypes}
-        onSaveAppearance={handleSaveAppearance}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'appearance' && (
+        <>
+          <div className="text-sm text-gray-500 italic pl-1">
+            ⚙️ Настройка фона и цвета кнопок вкладок
+          </div>
+          <TabsAppearance
+            schema={tabsSchema}
+            settings={data}
+            onChange={handleFieldChange}
+            fieldTypes={fieldTypes}
+            onSaveAppearance={handleSaveAppearance}
+            uiDefaults={uiDefaults}
+          />
+        </>
+      )}
 
       {showSaveButton && (
         <button

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/tabsSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/tabsSchema.js
@@ -1,18 +1,11 @@
 export const tabsSchema = [
-  {
-    key: 'custom_appearance',
-    label: 'Изменить внешний вид блока (фон, кнопки, текст)',
-    type: 'boolean',
-    default: false,
-    editable: true
-  },
-  {
+    {
     key: 'bg_color',
     label: 'Фон панели вкладок',
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'active_bg_color',
@@ -20,7 +13,7 @@ export const tabsSchema = [
     type: 'color',
     default: '#1976D2',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'active_text_color',
@@ -28,7 +21,7 @@ export const tabsSchema = [
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'text_color',
@@ -36,7 +29,7 @@ export const tabsSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'border_color',
@@ -44,7 +37,7 @@ export const tabsSchema = [
     type: 'color',
     default: 'rgba(0,0,0,0.1)',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'hover_bg_color',
@@ -52,7 +45,7 @@ export const tabsSchema = [
     type: 'color',
     default: 'transparent',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'hover_text_color',
@@ -60,7 +53,7 @@ export const tabsSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'tab_spacing',
@@ -68,7 +61,7 @@ export const tabsSchema = [
     type: 'number',
     default: 12,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size_tab',
@@ -76,7 +69,7 @@ export const tabsSchema = [
     type: 'fontsize',
     default: 14,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'show_cart_button',
@@ -84,7 +77,7 @@ export const tabsSchema = [
     type: 'boolean',
     default: true,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'cart_bg_color',
@@ -92,7 +85,7 @@ export const tabsSchema = [
     type: 'color',
     default: '#1976D2',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'cart_text_color',
@@ -100,7 +93,7 @@ export const tabsSchema = [
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'cart_hover_bg_color',
@@ -108,7 +101,7 @@ export const tabsSchema = [
     type: 'color',
     default: '#1565C0',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'cart_hover_text_color',
@@ -116,7 +109,7 @@ export const tabsSchema = [
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'cart_badge_bg_color',
@@ -124,7 +117,7 @@ export const tabsSchema = [
     type: 'color',
     default: '#EF4444',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'cart_badge_text_color',
@@ -132,7 +125,7 @@ export const tabsSchema = [
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'cart_badge_hover_bg_color',
@@ -140,7 +133,7 @@ export const tabsSchema = [
     type: 'color',
     default: '#DC2626',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'cart_badge_hover_text_color',
@@ -148,6 +141,6 @@ export const tabsSchema = [
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/Editor.jsx
@@ -4,12 +4,14 @@ import { navigationSchema } from './navigationSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import NavigationItemsEditor from './ItemsEditor'
 import NavigationAppearance from './Appearance'
+import { Tabs, Tab } from '@/components/ui/tabs'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 
 export default function NavigationEditor({ block, data, onChange, slug }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
   const [items, setItems] = useState([])
+  const [activeTab, setActiveTab] = useState('data')
   const [showToast, setShowToast] = useState(false)
 
   useEffect(() => {
@@ -51,28 +53,38 @@ export default function NavigationEditor({ block, data, onChange, slug }) {
         <div className="text-green-600 text-sm font-medium">✅ Внешний вид сохранён</div>
       )}
 
-      <div className="text-sm text-gray-500 italic pl-1">
-        📁 Навигация: редактирование пунктов и внешнего вида блока
-      </div>
+      <Tabs value={activeTab} onChange={setActiveTab} className="mb-4">
+        <Tab value="data">Данные</Tab>
+        <Tab value="appearance">Дизайн</Tab>
+      </Tabs>
 
-      <NavigationItemsEditor
-        items={items}
-        siteName={site_name}
-        siteData={siteData}
-        setData={setData}
-        setItems={setItems}
-        onChange={onChange}
-        setShowToast={setShowToast}
-      />
+      {activeTab === 'data' && (
+        <NavigationItemsEditor
+          items={items}
+          siteName={site_name}
+          siteData={siteData}
+          setData={setData}
+          setItems={setItems}
+          onChange={onChange}
+          setShowToast={setShowToast}
+        />
+      )}
 
-      <NavigationAppearance
-        schema={navigationSchema}
-        settings={data}
-        onChange={handleFieldChange}
-        fieldTypes={fieldTypes}
-        onSaveAppearance={handleSaveAppearance}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'appearance' && (
+        <>
+          <div className="text-sm text-gray-500 italic pl-1">
+            📁 Навигация: редактирование пунктов и внешнего вида блока
+          </div>
+          <NavigationAppearance
+            schema={navigationSchema}
+            settings={data}
+            onChange={handleFieldChange}
+            fieldTypes={fieldTypes}
+            onSaveAppearance={handleSaveAppearance}
+            uiDefaults={uiDefaults}
+          />
+        </>
+      )}
 
       {showSaveButton && (
         <button

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/NavigationPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/NavigationPreview.jsx
@@ -32,30 +32,21 @@ export default function NavigationPreview({ settings }) {
   useEffect(() => {
     if (!data?.ui_schema) return
 
-    const useCustom = settings?.custom_appearance === true
+    applyCssVariablesFromUiSchema(data.ui_schema)
     const css = {}
-
-    if (useCustom) {
-      Object.keys(blockSettings).forEach((key) => {
-        if (key.includes('color') || key.startsWith('bg_')) {
-          css[`--${key.replace(/_/g, '-')}`] = blockSettings[key]
-        }
-        if (key === 'hover_color') {
-          css['--link-hover-color'] = blockSettings[key]
-        }
-      })
-
-      console.log('[🧩 custom theme] styleVars:', css)
-      setStyleVars(css)
-    } else {
-      console.log('[🌐 global theme] fallback to ui_schema')
-      applyCssVariablesFromUiSchema(data.ui_schema)
-      setStyleVars({})
-    }
+    Object.keys(blockSettings).forEach((key) => {
+      if (key.includes('color') || key.startsWith('bg_')) {
+        css[`--${key.replace(/_/g, '-')}`] = blockSettings[key]
+      }
+      if (key === 'hover_color') {
+        css['--link-hover-color'] = blockSettings[key]
+      }
+    })
+    setStyleVars(css)
 
     console.log('[📦 blockSettings]:', blockSettings)
     console.log('[⚙️ settings]:', settings)
-  }, [data?.ui_schema, settings?.custom_appearance, settings])
+  }, [data?.ui_schema, settings])
 
   if (!nav?.length) {
     // Этот div можно оставить с p-4, так как он служит сообщением об отсутствии контента

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/navigationSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/navigationSchema.js
@@ -1,18 +1,11 @@
 export const navigationSchema = [
-  {
-    key: 'custom_appearance',
-    label: 'Изменить внешний вид блока (цвета, граница, фон)',
-    type: 'boolean',
-    default: false,
-    editable: true
-  },
-  {
+    {
     key: 'bg_color',
     label: 'Фон навигации',
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'text_color',
@@ -20,7 +13,7 @@ export const navigationSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'hover_color',
@@ -28,7 +21,7 @@ export const navigationSchema = [
     type: 'color',
     default: '#1976D2',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'hover_bg_color',
@@ -36,7 +29,7 @@ export const navigationSchema = [
     type: 'color',
     default: 'transparent',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'active_bg_color',
@@ -44,7 +37,7 @@ export const navigationSchema = [
     type: 'color',
     default: 'transparent',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'active_text_color',
@@ -52,7 +45,7 @@ export const navigationSchema = [
     type: 'color',
     default: '#1976D2',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'border_color',
@@ -60,7 +53,7 @@ export const navigationSchema = [
     type: 'color',
     default: '#E5E7EB',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'show_border',
@@ -68,7 +61,7 @@ export const navigationSchema = [
     type: 'boolean',
     default: true,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'tab_spacing',
@@ -76,7 +69,7 @@ export const navigationSchema = [
     type: 'number',
     default: 24,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size',
@@ -84,7 +77,7 @@ export const navigationSchema = [
     type: 'number',
     default: 16,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'padding_x',
@@ -92,7 +85,7 @@ export const navigationSchema = [
     type: 'number',
     default: 24,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'padding_y',
@@ -100,6 +93,6 @@ export const navigationSchema = [
     type: 'number',
     default: 12,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
@@ -6,12 +6,14 @@ import { fieldTypes } from '@/components/fields/fieldTypes'
 import ProductsItemsEditor from './ItemsEditor'
 import ProductsAppearance from './Appearance'
 import PopularItemsPreview from './PopularItemsPreview'
+import { Tabs, Tab } from '@/components/ui/tabs'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
 export default function ProductsEditor({ block, slug, onChange }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
+  const [activeTab, setActiveTab] = useState('data')
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
 
@@ -72,27 +74,37 @@ export default function ProductsEditor({ block, slug, onChange }) {
         </div>
       )}
 
-      <div className="text-sm text-gray-500 italic pl-1">
-        ⚙️ Настройка внешнего вида карточек товаров
-      </div>
+      <Tabs value={activeTab} onChange={setActiveTab} className="mb-4">
+        <Tab value="data">Данные</Tab>
+        <Tab value="appearance">Дизайн</Tab>
+      </Tabs>
 
-      <ProductsItemsEditor
-        schema={createProductsDataSchema(settingsState?.cards_count || 3)}
-        data={dataState}
-        settings={settingsState}
-        onTextChange={handleDataChange}
-        onSaveData={() => handleSaveData(dataState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'data' && (
+        <ProductsItemsEditor
+          schema={createProductsDataSchema(settingsState?.cards_count || 3)}
+          data={dataState}
+          settings={settingsState}
+          onTextChange={handleDataChange}
+          onSaveData={() => handleSaveData(dataState)}
+          uiDefaults={uiDefaults}
+        />
+      )}
 
-      <ProductsAppearance
-        schema={productsSchema}
-        settings={settingsState}
-        onChange={handleFieldChange}
-        fieldTypes={fieldTypes}
-        onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'appearance' && (
+        <>
+          <div className="text-sm text-gray-500 italic pl-1">
+            ⚙️ Настройка внешнего вида карточек товаров
+          </div>
+          <ProductsAppearance
+            schema={productsSchema}
+            settings={settingsState}
+            onChange={handleFieldChange}
+            fieldTypes={fieldTypes}
+            onSaveAppearance={() => handleSaveAppearance(settingsState)}
+            uiDefaults={uiDefaults}
+          />
+        </>
+      )}
 
       {(showDataButton || showAppearanceButton) && (
         <button

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItems.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItems.jsx
@@ -1,29 +1,10 @@
 import pizzaImg from '/images/8.webp'
 
 export const PopularItems = ({ settings = {}, data = {}, commonSettings = {} }) => {
-  const isCustom = settings?.custom_appearance === true
-
-  const source = isCustom
-    ? settings
-    : {
-        bg_color: commonSettings.background?.card,
-        border_color: commonSettings.text?.primary,
-        title_color: commonSettings.text?.primary,
-        price_color: commonSettings.text?.secondary,
-        card_shadow: 'low',
-        card_radius: 12,
-        font_size_title: 16,
-        font_size_price: 14,
-        spacing_x: 16,
-        image_size: 'medium',
-        padding_top: 32,
-        padding_bottom: 100,
-      }
-
-  const backgroundColor = source?.bg_color || '#FFFFFF'
-  const borderColor = source?.border_color || '#212121'
-  const titleColor = source?.title_color || '#212121'
-  const priceColor = source?.price_color || '#666666'
+  const backgroundColor = settings.bg_color ?? commonSettings.background?.card ?? '#FFFFFF'
+  const borderColor = settings.border_color ?? commonSettings.text?.primary ?? '#212121'
+  const titleColor = settings.title_color ?? commonSettings.text?.primary ?? '#212121'
+  const priceColor = settings.price_color ?? commonSettings.text?.secondary ?? '#666666'
 
   const shadowMap = {
     none: 'shadow-none',
@@ -31,21 +12,21 @@ export const PopularItems = ({ settings = {}, data = {}, commonSettings = {} }) 
     medium: 'shadow',
     high: 'shadow-lg',
   }
-  const cardShadow = shadowMap[source?.card_shadow] || 'shadow-sm'
+  const cardShadow = shadowMap[settings.card_shadow ?? 'low'] || 'shadow-sm'
 
-  const radius = source?.card_radius || 12
-  const spacingX = source?.spacing_x || 16
-  const fontSizeTitle = source?.font_size_title || 16
-  const fontSizePrice = source?.font_size_price || 14
-  const paddingTop = source?.padding_top ?? 32
-  const paddingBottom = source?.padding_bottom ?? 40
+  const radius = settings.card_radius ?? 12
+  const spacingX = settings.spacing_x ?? 16
+  const fontSizeTitle = settings.font_size_title ?? 16
+  const fontSizePrice = settings.font_size_price ?? 14
+  const paddingTop = settings.padding_top ?? 32
+  const paddingBottom = settings.padding_bottom ?? 40
 
   const imageSizeMap = {
     small: 'w-16 h-16',
     medium: 'w-24 h-24',
     large: 'w-32 h-32',
   }
-  const imageSize = imageSizeMap[source?.image_size] || 'w-24 h-24'
+  const imageSize = imageSizeMap[settings.image_size ?? 'medium'] || 'w-24 h-24'
 
   const defaultItems = [
     { id: 1, name: 'Пепперони фреш', price: 'от 409 ₽', img_url: pizzaImg },

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItemsPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItemsPreview.jsx
@@ -11,26 +11,14 @@ export default function PopularItemsPreview({ settings = {}, data = {}, commonSe
   useEffect(() => {
     if (!globalSiteData?.ui_schema) return
 
-    if (settings?.custom_appearance) {
-      const vars = {}
-      Object.entries(settings).forEach(([key, val]) => {
-        if (key.includes('color') || key.startsWith('bg_')) {
-          vars[`--${key.replace(/_/g, '-')}`] = val
-        }
-      })
-
-      const varsJson = JSON.stringify(vars)
-      const styleVarsJson = JSON.stringify(styleVars)
-
-      if (varsJson !== styleVarsJson) {
-        setStyleVars(vars)
+    applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+    const vars = {}
+    Object.entries(settings).forEach(([key, val]) => {
+      if (key.includes('color') || key.startsWith('bg_')) {
+        vars[`--${key.replace(/_/g, '-')}`] = val
       }
-    } else {
-      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
-      if (Object.keys(styleVars).length > 0) {
-        setStyleVars({})
-      }
-    }
+    })
+    setStyleVars(vars)
   }, [settings, globalSiteData?.ui_schema])
 
   return (

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/productsSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/productsSchema.js
@@ -1,18 +1,11 @@
 export const productsSchema = [
-  {
-    key: 'custom_appearance',
-    label: 'Изменить внешний вид блока (фон, рамка, текст)',
-    type: 'boolean',
-    default: false,
-    editable: true
-  },
-  {
+    {
     key: 'bg_color',
     label: 'Фон карточки',
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'border_color',
@@ -20,7 +13,7 @@ export const productsSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'title_color',
@@ -28,7 +21,7 @@ export const productsSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'price_color',
@@ -36,7 +29,7 @@ export const productsSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_shadow',
@@ -45,7 +38,7 @@ export const productsSchema = [
     options: ['none', 'low', 'medium', 'high'],
     default: 'low',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_radius',
@@ -53,7 +46,7 @@ export const productsSchema = [
     type: 'number',
     default: 12,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size_title',
@@ -61,7 +54,7 @@ export const productsSchema = [
     type: 'fontsize',
     default: 16,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size_price',
@@ -69,7 +62,7 @@ export const productsSchema = [
     type: 'fontsize',
     default: 14,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'spacing_x',
@@ -77,7 +70,7 @@ export const productsSchema = [
     type: 'number',
     default: 16,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'image_size',
@@ -85,7 +78,7 @@ export const productsSchema = [
     type: 'number',
     default: 96,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'padding_top',
@@ -93,7 +86,7 @@ export const productsSchema = [
     type: 'number',
     default: 32,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'padding_bottom',
@@ -101,7 +94,7 @@ export const productsSchema = [
     type: 'number',
     default: 40,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'cards_count',
@@ -109,6 +102,6 @@ export const productsSchema = [
     type: 'number',
     default: 3,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/Editor.jsx
@@ -4,11 +4,13 @@ import { productGridSchema } from './productGridSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import ProductGridItemsEditor from './ItemsEditor'
 import ProductGridAppearance from './Appearance'
+import { Tabs, Tab } from '@/components/ui/tabs'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 
 export default function ProductGridEditor({ block, data, onChange, slug }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
+  const [activeTab, setActiveTab] = useState('data')
   const [showToast, setShowToast] = useState(false)
 
   const {
@@ -39,27 +41,37 @@ export default function ProductGridEditor({ block, data, onChange, slug }) {
         <div className="text-green-600 text-sm font-medium">✅ Внешний вид сохранён</div>
       )}
 
-      <div className="text-sm text-gray-500 italic pl-1">
-        ⚙️ Настройка карточек товаров: фон, кнопка, текст
-      </div>
+      <Tabs value={activeTab} onChange={setActiveTab} className="mb-4">
+        <Tab value="data">Данные</Tab>
+        <Tab value="appearance">Дизайн</Tab>
+      </Tabs>
 
-      <ProductGridItemsEditor
-        settings={data}
-        siteName={site_name}
-        siteData={siteData}
-        setData={setData}
-        onChange={onChange}
-        setShowToast={setShowToast}
-      />
+      {activeTab === 'data' && (
+        <ProductGridItemsEditor
+          settings={data}
+          siteName={site_name}
+          siteData={siteData}
+          setData={setData}
+          onChange={onChange}
+          setShowToast={setShowToast}
+        />
+      )}
 
-      <ProductGridAppearance
-        schema={productGridSchema}
-        settings={data}
-        onChange={handleFieldChange}
-        fieldTypes={fieldTypes}
-        onSaveAppearance={handleSaveAppearance}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'appearance' && (
+        <>
+          <div className="text-sm text-gray-500 italic pl-1">
+            ⚙️ Настройка карточек товаров: фон, кнопка, текст
+          </div>
+          <ProductGridAppearance
+            schema={productGridSchema}
+            settings={data}
+            onChange={handleFieldChange}
+            fieldTypes={fieldTypes}
+            onSaveAppearance={handleSaveAppearance}
+            uiDefaults={uiDefaults}
+          />
+        </>
+      )}
 
       {showSaveButton && (
         <button

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/productGridSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/productGridSchema.js
@@ -1,18 +1,11 @@
 export const productGridSchema = [
-  {
-    key: 'custom_appearance',
-    label: 'Изменить внешний вид карточек (фон, текст, кнопка)',
-    type: 'boolean',
-    default: false,
-    editable: true
-  },
-  {
+    {
     key: 'bg_color',
     label: 'Фон карточки',
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'text_color',
@@ -20,7 +13,7 @@ export const productGridSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'price_bg_color',
@@ -28,7 +21,7 @@ export const productGridSchema = [
     type: 'color',
     default: 'rgba(0,0,0,0.05)',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'price_color',
@@ -36,7 +29,7 @@ export const productGridSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'button_bg_color',
@@ -44,7 +37,7 @@ export const productGridSchema = [
     type: 'color',
     default: '#1976D2',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'button_text_color',
@@ -52,7 +45,7 @@ export const productGridSchema = [
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'button_hover_color',
@@ -60,7 +53,7 @@ export const productGridSchema = [
     type: 'color',
     default: '#1565C0',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_border_radius',
@@ -68,7 +61,7 @@ export const productGridSchema = [
     type: 'number',
     default: 16,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_shadow',
@@ -77,7 +70,7 @@ export const productGridSchema = [
     options: ['none', 'low', 'medium', 'high'],
     default: 'medium',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size_name',
@@ -85,7 +78,7 @@ export const productGridSchema = [
     type: 'fontsize',
     default: 16,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size_price',
@@ -93,7 +86,7 @@ export const productGridSchema = [
     type: 'fontsize',
     default: 14,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size_desc',
@@ -101,7 +94,7 @@ export const productGridSchema = [
     type: 'fontsize',
     default: 14,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'columns_desktop',
@@ -109,7 +102,7 @@ export const productGridSchema = [
     type: 'number',
     default: 4,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'columns_tablet',
@@ -117,7 +110,7 @@ export const productGridSchema = [
     type: 'number',
     default: 3,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'columns_mobile',
@@ -125,6 +118,6 @@ export const productGridSchema = [
     type: 'number',
     default: 2,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
@@ -6,12 +6,14 @@ import { fieldTypes } from '@/components/fields/fieldTypes'
 import PromoItemsEditor from './ItemsEditor'
 import PromoAppearance from './Appearance'
 import PromoCardsPreview from './PromoCardsPreview'
+import { Tabs, Tab } from '@/components/ui/tabs'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
 export default function PromoEditor({ block, slug, onChange }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
+  const [activeTab, setActiveTab] = useState('data')
 
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
@@ -74,27 +76,37 @@ export default function PromoEditor({ block, slug, onChange }) {
         </div>
       )}
 
-      <div className="text-sm text-gray-500 italic pl-1">
-        ⚙️ Настройка фона карточек, рамок и текста
-      </div>
+      <Tabs value={activeTab} onChange={setActiveTab} className="mb-4">
+        <Tab value="data">Данные</Tab>
+        <Tab value="appearance">Дизайн</Tab>
+      </Tabs>
 
-      <PromoItemsEditor
-        schema={promoDataSchema}
-        data={dataState}
-        settings={settingsState}
-        onTextChange={handleDataChange}
-        onSaveData={() => handleSaveData(dataState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'data' && (
+        <PromoItemsEditor
+          schema={promoDataSchema}
+          data={dataState}
+          settings={settingsState}
+          onTextChange={handleDataChange}
+          onSaveData={() => handleSaveData(dataState)}
+          uiDefaults={uiDefaults}
+        />
+      )}
 
-      <PromoAppearance
-        schema={promoSchema}
-        settings={settingsState}
-        onChange={handleFieldChange}
-        fieldTypes={fieldTypes}
-        onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'appearance' && (
+        <>
+          <div className="text-sm text-gray-500 italic pl-1">
+            ⚙️ Настройка фона карточек, рамок и текста
+          </div>
+          <PromoAppearance
+            schema={promoSchema}
+            settings={settingsState}
+            onChange={handleFieldChange}
+            fieldTypes={fieldTypes}
+            onSaveAppearance={() => handleSaveAppearance(settingsState)}
+            uiDefaults={uiDefaults}
+          />
+        </>
+      )}
 
       {(showDataButton || showSaveButton) && (
         <button

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/PromoCards.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/PromoCards.jsx
@@ -2,44 +2,21 @@ import pizzaImg from '/images/9.webp'
 import { useRef } from 'react'
 
 export const PromoCards = ({ settings = {}, data = {}, commonSettings = {} }) => {
-  const isCustom = settings?.custom_appearance === true
-
-  const source = isCustom
-    ? settings
-    : {
-        bg_color: commonSettings.background?.card,
-        border_color: commonSettings.text?.primary,
-        title_color: commonSettings.text?.primary,
-        desc_color: commonSettings.text?.secondary,
-        title_size: 14,
-        desc_size: 12,
-        border_radius: 16,
-        gap: 16,
-        card_style: 'flat',
-        hover_effect: 'scale',
-        hover_shadow: 'medium',
-        block_padding_y: 24,
-        card_width: 192,
-        card_padding: 6,
-      }
-
-  const {
-    bg_color = '#FFFFFF',
-    border_color = '#212121',
-    title_color = '#212121',
-    desc_color = '#666666',
-    title_size = 14,
-    desc_size = 12,
-    border_radius = 16,
-    gap = 16,
-    card_style = 'flat',
-    hover_effect = 'scale',
-    hover_shadow = 'medium',
-    block_padding_y = 24,
-    card_width = 192,
-    card_padding = 6,
-    cards_count = 6,
-  } = source
+  const bg_color = settings.bg_color ?? commonSettings.background?.card ?? '#FFFFFF'
+  const border_color = settings.border_color ?? commonSettings.text?.primary ?? '#212121'
+  const title_color = settings.title_color ?? commonSettings.text?.primary ?? '#212121'
+  const desc_color = settings.desc_color ?? commonSettings.text?.secondary ?? '#666666'
+  const title_size = settings.title_size ?? 14
+  const desc_size = settings.desc_size ?? 12
+  const border_radius = settings.border_radius ?? 16
+  const gap = settings.gap ?? 16
+  const card_style = settings.card_style ?? 'flat'
+  const hover_effect = settings.hover_effect ?? 'scale'
+  const hover_shadow = settings.hover_shadow ?? 'medium'
+  const block_padding_y = settings.block_padding_y ?? 24
+  const card_width = settings.card_width ?? 192
+  const card_padding = settings.card_padding ?? 6
+  const cards_count = settings.cards_count ?? 6
 
   const defaultCards = [
     { id: 1, title: 'Горячая пицца', desc: 'Доставка за 30 минут', img_url: pizzaImg },

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/PromoCardsPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/PromoCardsPreview.jsx
@@ -11,26 +11,14 @@ export default function PromoCardsPreview({ settings = {}, data = {}, commonSett
   useEffect(() => {
     if (!globalSiteData?.ui_schema) return
 
-    if (settings?.custom_appearance) {
-      const vars = {}
-      Object.entries(settings).forEach(([key, val]) => {
-        if (key.includes('color') || key.startsWith('bg_')) {
-          vars[`--${key.replace(/_/g, '-')}`] = val
-        }
-      })
-
-      const varsJson = JSON.stringify(vars)
-      const styleVarsJson = JSON.stringify(styleVars)
-
-      if (varsJson !== styleVarsJson) {
-        setStyleVars(vars)
+    applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+    const vars = {}
+    Object.entries(settings).forEach(([key, val]) => {
+      if (key.includes('color') || key.startsWith('bg_')) {
+        vars[`--${key.replace(/_/g, '-')}`] = val
       }
-    } else {
-      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
-      if (Object.keys(styleVars).length > 0) {
-        setStyleVars({})
-      }
-    }
+    })
+    setStyleVars(vars)
   }, [settings, globalSiteData?.ui_schema])
 
   return (

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/promoSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/promoSchema.js
@@ -1,18 +1,11 @@
 export const promoSchema = [
-  {
-    key: 'custom_appearance',
-    label: 'Изменить внешний вид блока (фон, текст, рамка)',
-    type: 'boolean',
-    default: false,
-    editable: true
-  },
-  {
+    {
     key: 'bg_color',
     label: 'Фон карточек',
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'border_color',
@@ -20,7 +13,7 @@ export const promoSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'title_color',
@@ -28,7 +21,7 @@ export const promoSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'desc_color',
@@ -36,7 +29,7 @@ export const promoSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'title_size',
@@ -44,7 +37,7 @@ export const promoSchema = [
     type: 'fontsize',
     default: 14,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'desc_size',
@@ -52,7 +45,7 @@ export const promoSchema = [
     type: 'fontsize',
     default: 12,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'border_radius',
@@ -60,7 +53,7 @@ export const promoSchema = [
     type: 'number',
     default: 16,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'gap',
@@ -68,7 +61,7 @@ export const promoSchema = [
     type: 'number',
     default: 16,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_width',
@@ -76,7 +69,7 @@ export const promoSchema = [
     type: 'number',
     default: 192,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_padding',
@@ -84,7 +77,7 @@ export const promoSchema = [
     type: 'number',
     default: 6,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_style',
@@ -93,7 +86,7 @@ export const promoSchema = [
     options: ['flat', 'glass', 'elevated'],
     default: 'flat',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'hover_effect',
@@ -102,7 +95,7 @@ export const promoSchema = [
     options: ['none', 'scale', 'glow', 'border'],
     default: 'scale',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'hover_shadow',
@@ -111,7 +104,7 @@ export const promoSchema = [
     options: ['none', 'low', 'medium', 'high'],
     default: 'medium',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'cards_count',
@@ -119,6 +112,6 @@ export const promoSchema = [
     type: 'number',
     default: 6,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
@@ -8,12 +8,14 @@ import {
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import QuickInfoItemsEditor from './ItemsEditor'
 import QuickInfoAppearance from './Appearance'
+import { Tabs, Tab } from '@/components/ui/tabs'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
 export default function QuickInfoEditor({ block, slug, onChange }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
+  const [activeTab, setActiveTab] = useState('data')
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
 
@@ -84,27 +86,37 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
         </div>
       )}
 
-      <div className="text-sm text-gray-500 italic pl-1">
-        ⚙️ Настройка фона и цветов текста для блока с условиями доставки
-      </div>
+      <Tabs value={activeTab} onChange={setActiveTab} className="mb-4">
+        <Tab value="data">Данные</Tab>
+        <Tab value="appearance">Дизайн</Tab>
+      </Tabs>
 
-      <QuickInfoItemsEditor
-        schema={createQuickInfoDataSchema(settingsState?.grid_cols || 4)}
-        data={dataState}
-        settings={settingsState}
-        onTextChange={handleTextFieldChange}
-        onSaveData={() => handleSaveData(dataState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'data' && (
+        <QuickInfoItemsEditor
+          schema={createQuickInfoDataSchema(settingsState?.grid_cols || 4)}
+          data={dataState}
+          settings={settingsState}
+          onTextChange={handleTextFieldChange}
+          onSaveData={() => handleSaveData(dataState)}
+          uiDefaults={uiDefaults}
+        />
+      )}
 
-      <QuickInfoAppearance
-        schema={quickInfoSchema}
-        settings={settingsState}
-        onChange={handleFieldChange}
-        fieldTypes={fieldTypes}
-        onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'appearance' && (
+        <>
+          <div className="text-sm text-gray-500 italic pl-1">
+            ⚙️ Настройка фона и цветов текста для блока с условиями доставки
+          </div>
+          <QuickInfoAppearance
+            schema={quickInfoSchema}
+            settings={settingsState}
+            onChange={handleFieldChange}
+            fieldTypes={fieldTypes}
+            onSaveAppearance={() => handleSaveAppearance(settingsState)}
+            uiDefaults={uiDefaults}
+          />
+        </>
+      )}
 
       {(showDataButton || showAppearanceButton) && (
         <button

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfo.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfo.jsx
@@ -2,42 +2,18 @@ import React from 'react'
 import { defaultQuickInfoItems } from './quickInfoDataSchema'
 
 export const QuickInfo = ({ settings = {}, data = {}, commonSettings = {} }) => {
-  const isCustom = settings?.custom_appearance === true
-
-  const defaultQuickInfoSettings = {
-    gap: 24,
-    grid_cols: 4,
-    border_radius: 12,
-    font_size_title: 14,
-    font_size_desc: 16,
-    card_bg_color: '#FFFFFF',
-    card_border_color: '#E5E7EB',
-    card_variant: 'flat',
-    show_cards: true,
-  }
-
-  const source = isCustom
-    ? settings
-    : {
-        ...defaultQuickInfoSettings,
-        bg_color: commonSettings.background?.surface,
-        title_color: commonSettings.text?.secondary,
-        desc_color: commonSettings.text?.accent,
-        text_color: commonSettings.text?.primary,
-      }
-
-  const bgColor = source?.bg_color || '#F3F4F6'
-  const titleColor = source?.title_color || '#6B7280'
-  const descColor = source?.desc_color || '#1976D2'
-  const gap = source?.gap || 24
-  const cols = source?.grid_cols || 4
-  const borderRadius = source?.border_radius || 12
-  const fontSizeTitle = source?.font_size_title || 14
-  const fontSizeDesc = source?.font_size_desc || 16
-  const cardBg = source?.card_bg_color || '#FFFFFF'
-  const cardBorder = source?.card_border_color || '#E5E7EB'
-  const variant = source?.card_variant || 'flat'
-  const showCards = source?.show_cards !== false
+  const bgColor = settings.bg_color ?? commonSettings.background?.surface ?? '#F3F4F6'
+  const titleColor = settings.title_color ?? commonSettings.text?.secondary ?? '#6B7280'
+  const descColor = settings.desc_color ?? commonSettings.text?.accent ?? '#1976D2'
+  const gap = settings.gap ?? 24
+  const cols = settings.grid_cols ?? 4
+  const borderRadius = settings.border_radius ?? 12
+  const fontSizeTitle = settings.font_size_title ?? 14
+  const fontSizeDesc = settings.font_size_desc ?? 16
+  const cardBg = settings.card_bg_color ?? '#FFFFFF'
+  const cardBorder = settings.card_border_color ?? '#E5E7EB'
+  const variant = settings.card_variant ?? 'flat'
+  const showCards = settings.show_cards ?? true
 
   const defaultItems = defaultQuickInfoItems
 

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfoPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/QuickInfoPreview.jsx
@@ -11,26 +11,14 @@ export default function QuickInfoPreview({ settings = {}, data = {}, commonSetti
   useEffect(() => {
     if (!globalSiteData?.ui_schema) return
 
-    if (settings?.custom_appearance) {
-      const vars = {}
-      Object.entries(settings).forEach(([key, val]) => {
-        if (key.includes('color') || key.startsWith('bg_')) {
-          vars[`--${key.replace(/_/g, '-')}`] = val
-        }
-      })
-
-      const varsJson = JSON.stringify(vars)
-      const styleVarsJson = JSON.stringify(styleVars)
-
-      if (varsJson !== styleVarsJson) {
-        setStyleVars(vars)
+    applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+    const vars = {}
+    Object.entries(settings).forEach(([key, val]) => {
+      if (key.includes('color') || key.startsWith('bg_')) {
+        vars[`--${key.replace(/_/g, '-')}`] = val
       }
-    } else {
-      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
-      if (Object.keys(styleVars).length > 0) {
-        setStyleVars({})
-      }
-    }
+    })
+    setStyleVars(vars)
   }, [settings, globalSiteData?.ui_schema])
 
   return (

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/quickInfoSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/quickInfoSchema.js
@@ -1,18 +1,11 @@
 export const quickInfoSchema = [
-  {
-    key: 'custom_appearance',
-    label: 'Изменить внешний вид блока (фон и цвета текста)',
-    type: 'boolean',
-    default: false,
-    editable: true
-  },
-  {
+    {
     key: 'bg_color',
     label: 'Фон блока',
     type: 'color',
     default: '#E3F2FD',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'title_color',
@@ -20,7 +13,7 @@ export const quickInfoSchema = [
     type: 'color',
     default: '#6B7280',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'desc_color',
@@ -28,7 +21,7 @@ export const quickInfoSchema = [
     type: 'color',
     default: '#1976D2',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
 
   // 🔧 Новые параметры
@@ -38,7 +31,7 @@ export const quickInfoSchema = [
     type: 'number',
     default: 24,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'grid_cols',
@@ -46,7 +39,7 @@ export const quickInfoSchema = [
     type: 'number',
     default: 4,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'border_radius',
@@ -54,7 +47,7 @@ export const quickInfoSchema = [
     type: 'number',
     default: 12,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size_title',
@@ -62,7 +55,7 @@ export const quickInfoSchema = [
     type: 'number',
     default: 14,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'font_size_desc',
@@ -70,7 +63,7 @@ export const quickInfoSchema = [
     type: 'number',
     default: 16,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_bg_color',
@@ -78,7 +71,7 @@ export const quickInfoSchema = [
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_border_color',
@@ -86,7 +79,7 @@ export const quickInfoSchema = [
     type: 'color',
     default: '#E5E7EB',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_variant',
@@ -95,7 +88,7 @@ export const quickInfoSchema = [
     options: ['flat', 'border', 'hover-shadow'],
     default: 'flat',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'show_cards',
@@ -103,6 +96,6 @@ export const quickInfoSchema = [
     type: 'boolean',
     default: true,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
@@ -5,13 +5,14 @@ import { createReviewsDataSchema } from './reviewsDataSchema'
 import { fieldTypes } from '@/components/fields/fieldTypes'
 import ReviewsItemsEditor from './ItemsEditor'
 import ReviewsAppearance from './Appearance'
+import { Tabs, Tab } from '@/components/ui/tabs'
 import { useBlockAppearance } from '@blocks/forms/hooks/useBlockAppearance'
 import { useBlockData } from '@blocks/forms/hooks/useBlockData'
 
 export default function ReviewsEditor({ block, slug, onChange }) {
   const { data: siteData, site_name, setData } = useSiteSettings()
   const block_id = block?.real_id
-
+  const [activeTab, setActiveTab] = useState('data')
   const [dataState, setDataState] = useState(block?.data || {})
   const [settingsState, setSettingsState] = useState(block?.settings || {})
 
@@ -73,27 +74,37 @@ export default function ReviewsEditor({ block, slug, onChange }) {
         </div>
       )}
 
-      <div className="text-sm text-gray-500 italic pl-1">
-        ⚙️ Настройка карточек отзывов: фон, текст, рамка, звёзды
-      </div>
+      <Tabs value={activeTab} onChange={setActiveTab} className="mb-4">
+        <Tab value="data">Данные</Tab>
+        <Tab value="appearance">Дизайн</Tab>
+      </Tabs>
 
-      <ReviewsItemsEditor
-        schema={createReviewsDataSchema(settingsState?.reviews_count || 4)}
-        data={dataState}
-        settings={settingsState}
-        onTextChange={handleDataChange}
-        onSaveData={() => handleSaveData(dataState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'data' && (
+        <ReviewsItemsEditor
+          schema={createReviewsDataSchema(settingsState?.reviews_count || 4)}
+          data={dataState}
+          settings={settingsState}
+          onTextChange={handleDataChange}
+          onSaveData={() => handleSaveData(dataState)}
+          uiDefaults={uiDefaults}
+        />
+      )}
 
-      <ReviewsAppearance
-        schema={reviewsSchema}
-        settings={settingsState}
-        onChange={handleFieldChange}
-        fieldTypes={fieldTypes}
-        onSaveAppearance={() => handleSaveAppearance(settingsState)}
-        uiDefaults={uiDefaults}
-      />
+      {activeTab === 'appearance' && (
+        <>
+          <div className="text-sm text-gray-500 italic pl-1">
+            ⚙️ Настройка карточек отзывов: фон, текст, рамка, звёзды
+          </div>
+          <ReviewsAppearance
+            schema={reviewsSchema}
+            settings={settingsState}
+            onChange={handleFieldChange}
+            fieldTypes={fieldTypes}
+            onSaveAppearance={() => handleSaveAppearance(settingsState)}
+            uiDefaults={uiDefaults}
+          />
+        </>
+      )}
 
       {(showDataButton || showSaveButton) && (
         <button

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Reviews.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Reviews.jsx
@@ -3,41 +3,21 @@ import pizzaImg from '/images/6.webp'
 import { defaultReviews } from './reviewsDataSchema'
 
 export const Reviews = ({ settings = {}, data = {}, commonSettings = {} }) => {
-  const isCustom = settings?.custom_appearance === true
+  const sectionBg = settings.section_bg_color ?? commonSettings.background?.muted ?? '#F9FAFB'
+  const textColor = settings.text_color ?? commonSettings.text?.primary ?? '#212121'
+  const subtleTextColor = settings.subtle_text_color ?? commonSettings.text?.secondary ?? '#6B7280'
+  const cardBg = settings.card_bg_color ?? commonSettings.background?.card ?? '#FFFFFF'
+  const cardBorder = settings.card_border_color ?? commonSettings.layout?.border_color ?? '#E5E7EB'
+  const ratingColor = settings.rating_color ?? commonSettings.icon?.rating ?? '#FACC15'
+  const primaryColor = settings.primary_color ?? commonSettings.text?.accent ?? '#1976D2'
 
-  const source = isCustom
-    ? settings
-    : {
-        section_bg_color: commonSettings.background?.muted,
-        text_color: commonSettings.text?.primary,
-        subtle_text_color: commonSettings.text?.secondary,
-        card_bg_color: commonSettings.background?.card,
-        card_border_color: commonSettings.layout?.border_color || '#E5E7EB',
-        rating_color: commonSettings.icon?.rating,
-        primary_color: commonSettings.text?.accent,
-        show_modal_button: true,
-        slider_enabled: true,
-        avatar_size: 'medium',
-        card_shadow: 'low',
-        transition_effect: 'slide',
-        reviews_count: defaultReviews.length,
-      }
-
-  const sectionBg = source?.section_bg_color || '#F9FAFB'
-  const textColor = source?.text_color || '#212121'
-  const subtleTextColor = source?.subtle_text_color || '#6B7280'
-  const cardBg = source?.card_bg_color || '#FFFFFF'
-  const cardBorder = source?.card_border_color || '#E5E7EB'
-  const ratingColor = source?.rating_color || '#FACC15'
-  const primaryColor = source?.primary_color || '#1976D2'
-
-  const avatarSize = source?.avatar_size === 'small' ? 32 : source?.avatar_size === 'large' ? 56 : 40
+  const avatarSize = settings.avatar_size === 'small' ? 32 : settings.avatar_size === 'large' ? 56 : 40
   const boxShadow =
-    source?.card_shadow === 'high'
+    settings.card_shadow === 'high'
       ? '0 8px 20px rgba(0,0,0,0.2)'
-      : source?.card_shadow === 'medium'
+      : settings.card_shadow === 'medium'
       ? '0 4px 12px rgba(0,0,0,0.1)'
-      : source?.card_shadow === 'low'
+      : settings.card_shadow === 'low'
       ? '0 2px 6px rgba(0,0,0,0.05)'
       : 'none'
 
@@ -51,7 +31,7 @@ export const Reviews = ({ settings = {}, data = {}, commonSettings = {} }) => {
         img_url: data[`review${idx + 1}_img`] ?? rev.img_url,
       }))
 
-  const reviews_count = source?.reviews_count || rawReviews.length
+  const reviews_count = settings.reviews_count ?? rawReviews.length
   const reviews = rawReviews.slice(0, reviews_count)
   const assetsBase = import.meta.env.VITE_ASSETS_URL || ''
 
@@ -77,7 +57,7 @@ export const Reviews = ({ settings = {}, data = {}, commonSettings = {} }) => {
   }, [reviews])
 
   useEffect(() => {
-    if (!source?.slider_enabled) return
+    if (settings.slider_enabled === false) return
     const slider = scrollRef.current
     if (!slider) return
 
@@ -113,7 +93,7 @@ export const Reviews = ({ settings = {}, data = {}, commonSettings = {} }) => {
       slider.removeEventListener('mouseup', handle)
       slider.removeEventListener('mouseleave', handle)
     }
-  }, [source?.slider_enabled])
+  }, [settings.slider_enabled])
 
   const ReviewModal = ({ onClose }) => (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
@@ -158,7 +138,7 @@ export const Reviews = ({ settings = {}, data = {}, commonSettings = {} }) => {
               ⭐ Нас рекомендуют
             </span>
           </div>
-          {source.show_modal_button && (
+          {settings.show_modal_button !== false && (
             <button
               className="text-sm font-medium transition hover:underline"
               style={{ color: primaryColor }}
@@ -171,7 +151,7 @@ export const Reviews = ({ settings = {}, data = {}, commonSettings = {} }) => {
 
         <div
           ref={scrollRef}
-          className={`flex gap-4 py-4 ${source.slider_enabled ? 'overflow-x-auto overflow-y-visible cursor-grab scrollbar-hide' : 'flex-wrap'}`}
+          className={`flex gap-4 py-4 ${settings.slider_enabled === false ? 'flex-wrap' : 'overflow-x-auto overflow-y-visible cursor-grab scrollbar-hide'}`}
         >
           {reviews.map((review, index) => (
             <div

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/ReviewsPreview.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/ReviewsPreview.jsx
@@ -11,26 +11,14 @@ export default function ReviewsPreview({ settings = {}, data = {}, commonSetting
   useEffect(() => {
     if (!globalSiteData?.ui_schema) return
 
-    if (settings?.custom_appearance) {
-      const vars = {}
-      Object.entries(settings).forEach(([key, val]) => {
-        if (key.includes('color') || key.startsWith('bg_')) {
-          vars[`--${key.replace(/_/g, '-')}`] = val
-        }
-      })
-
-      const varsJson = JSON.stringify(vars)
-      const styleVarsJson = JSON.stringify(styleVars)
-
-      if (varsJson !== styleVarsJson) {
-        setStyleVars(vars)
+    applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
+    const vars = {}
+    Object.entries(settings).forEach(([key, val]) => {
+      if (key.includes('color') || key.startsWith('bg_')) {
+        vars[`--${key.replace(/_/g, '-')}`] = val
       }
-    } else {
-      applyCssVariablesFromUiSchema(globalSiteData.ui_schema)
-      if (Object.keys(styleVars).length > 0) {
-        setStyleVars({})
-      }
-    }
+    })
+    setStyleVars(vars)
   }, [settings, globalSiteData?.ui_schema])
 
   return (

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/reviewsSchema.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/reviewsSchema.js
@@ -1,18 +1,11 @@
 export const reviewsSchema = [
-  {
-    key: 'custom_appearance',
-    label: 'Изменить внешний вид блока (фон, карточки, цвета)',
-    type: 'boolean',
-    default: false,
-    editable: true
-  },
-  {
+    {
     key: 'section_bg_color',
     label: 'Фон всей секции',
     type: 'color',
     default: '#F9FAFB',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'text_color',
@@ -20,7 +13,7 @@ export const reviewsSchema = [
     type: 'color',
     default: '#212121',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'subtle_text_color',
@@ -28,7 +21,7 @@ export const reviewsSchema = [
     type: 'color',
     default: '#6B7280',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_bg_color',
@@ -36,7 +29,7 @@ export const reviewsSchema = [
     type: 'color',
     default: '#FFFFFF',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_border_color',
@@ -44,7 +37,7 @@ export const reviewsSchema = [
     type: 'color',
     default: '#E5E7EB',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'rating_color',
@@ -52,7 +45,7 @@ export const reviewsSchema = [
     type: 'color',
     default: '#FACC15',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'primary_color',
@@ -60,7 +53,7 @@ export const reviewsSchema = [
     type: 'color',
     default: '#1976D2',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'show_modal_button',
@@ -68,7 +61,7 @@ export const reviewsSchema = [
     type: 'boolean',
     default: true,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'slider_enabled',
@@ -76,7 +69,7 @@ export const reviewsSchema = [
     type: 'boolean',
     default: true,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'avatar_size',
@@ -85,7 +78,7 @@ export const reviewsSchema = [
     options: ['small', 'medium', 'large'],
     default: 'medium',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'card_shadow',
@@ -94,7 +87,7 @@ export const reviewsSchema = [
     options: ['none', 'low', 'medium', 'high'],
     default: 'low',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'transition_effect',
@@ -103,7 +96,7 @@ export const reviewsSchema = [
     options: ['fade', 'slide', 'scale'],
     default: 'slide',
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   },
   {
     key: 'reviews_count',
@@ -111,6 +104,6 @@ export const reviewsSchema = [
     type: 'number',
     default: 4,
     editable: true,
-    visible_if: { custom_appearance: true }
+    visible: true
   }
 ]

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/hooks/useBlockAppearance.js
@@ -5,7 +5,6 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
   const [initialAppearance, setInitialAppearance] = useState({})
   const [readyToCheck, setReadyToCheck] = useState(false)
   const [showSavedToast, setShowSavedToast] = useState(false)
-  const [resetButton, setResetButton] = useState(false)
 
   const uiDefaults = {}
   for (const field of siteData?.ui_schema || []) {
@@ -17,7 +16,6 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
     }
   }
 
-  // авто-синхронизация синонимов
   if (uiDefaults.background_color && !uiDefaults.bg_color) {
     uiDefaults.bg_color = uiDefaults.background_color
   }
@@ -26,24 +24,17 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
   }
 
   useEffect(() => {
-    if (!data?.custom_appearance) {
-      setInitialAppearance({})
-      setReadyToCheck(false)
-      return
-    }
-
     const values = {}
     for (const field of schema) {
-      if (field.visible_if?.custom_appearance) {
-        values[field.key] = data[field.key] !== undefined ? data[field.key] : uiDefaults[field.key]
-      }
+      if (field.visible === false) continue
+      values[field.key] = data[field.key] !== undefined ? data[field.key] : uiDefaults[field.key]
     }
 
     setInitialAppearance(values)
 
     requestAnimationFrame(() => {
       const isChanged = schema.some(field => {
-        if (!field.visible_if?.custom_appearance) return false
+        if (field.visible === false) return false
         return data[field.key] !== values[field.key]
       })
       setReadyToCheck(isChanged)
@@ -51,53 +42,20 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
   }, [block_id])
 
   const handleFieldChange = (key, value) => {
-    if (key === 'custom_appearance' && value === false) {
-      const defaults = initBlockAppearanceFromCommon(siteData?.ui_schema || [], schema)
-      const updated = {
-        ...defaults,
-        custom_appearance: false,
-      }
-      console.log('✅ updating appearance with defaults (OFF):', updated)
-      handleSaveAppearance(updated)
-      onChange(prev => ({ ...prev, ...updated }))
-      return
-    }
-
-    if (key === 'custom_appearance' && value === true) {
-      const values = {}
-      for (const field of schema) {
-        if (field.visible_if?.custom_appearance) {
-          values[field.key] = data[field.key] !== undefined ? data[field.key] : uiDefaults[field.key]
-        }
-      }
-      const updated = {
-        ...values,
-        custom_appearance: true,
-      }
-      console.log('✅ updating appearance with defaults (ON):', updated)
-      onChange(prev => ({ ...prev, ...updated }))
-      return
-    }
-
     onChange(prev => {
       const updated = { ...prev, [key]: value }
-
-      if (prev.custom_appearance) {
-        const changed = schema.some(field => {
-          if (!field.visible_if?.custom_appearance) return false
-          return updated[field.key] !== initialAppearance[field.key]
-        })
-        requestAnimationFrame(() => setReadyToCheck(changed))
-      }
-
+      const changed = schema.some(field => {
+        if (field.visible === false) return false
+        return updated[field.key] !== initialAppearance[field.key]
+      })
+      requestAnimationFrame(() => setReadyToCheck(changed))
       return updated
     })
   }
 
   const hasAppearanceChanged = () => {
-    if (!readyToCheck || !data?.custom_appearance) return false
-    return schema.some(field => {
-      if (!field.visible_if?.custom_appearance) return false
+    return readyToCheck && schema.some(field => {
+      if (field.visible === false) return false
       return data[field.key] !== initialAppearance[field.key]
     })
   }
@@ -106,12 +64,9 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
     try {
       const filteredSettings = {}
       for (const field of schema) {
-        if (field.visible_if?.custom_appearance) {
-          filteredSettings[field.key] = settings[field.key]
-        }
+        if (field.visible === false) continue
+        filteredSettings[field.key] = settings[field.key]
       }
-
-      filteredSettings.custom_appearance = settings.custom_appearance
 
       const res = await fetch(
         `${import.meta.env.VITE_API_URL}/blocks/update-settings/${site_name}/${slug}/${block_id}`,
@@ -130,11 +85,7 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
       setInitialAppearance(filteredSettings)
       setReadyToCheck(false)
       setShowSavedToast(true)
-      setResetButton(true)
-      setTimeout(() => {
-        setShowSavedToast(false)
-        setResetButton(false)
-      }, 2000)
+      setTimeout(() => setShowSavedToast(false), 2000)
 
       if (setData) {
         setData(prev => {
@@ -157,14 +108,12 @@ export function useBlockAppearance({ schema, data, block_id, slug, siteData, sit
     }
   }
 
-  const showSaveButton = readyToCheck && data?.custom_appearance && hasAppearanceChanged()
-  console.log('[🔥 uiDefaults]', uiDefaults)
+  const showSaveButton = readyToCheck && hasAppearanceChanged()
 
   return {
     handleFieldChange,
     handleSaveAppearance,
     showSavedToast,
-    resetButton,
     showSaveButton,
     uiDefaults,
   }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/utils/initBlockAppearanceFromCommon.js
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/utils/initBlockAppearanceFromCommon.js
@@ -4,12 +4,8 @@ export function initBlockAppearanceFromCommon(schema, common = {}) {
   const result = {}
 
   for (const field of schema) {
-    if (
-      field.key !== 'custom_appearance' &&
-      field.visible_if?.custom_appearance === true
-    ) {
-      result[field.key] = common[field.key] ?? field.default ?? ''
-    }
+    if (field.visible === false) continue
+    result[field.key] = common[field.key] ?? field.default ?? ''
   }
 
   return result

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockAppearance.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockAppearance.jsx
@@ -11,10 +11,7 @@ export default function BlockAppearance({
 
 
   const renderField = (field) => {
-    if (field.visible_if) {
-      const [[depKey, depVal]] = Object.entries(field.visible_if)
-      if (settings?.[depKey] !== depVal) return null
-    }
+    if (field.visible === false) return null
 
     const FieldComponent = fieldTypes[field.type] || fieldTypes.text
     const value =


### PR DESCRIPTION
## Summary
- simplify `BlockAppearance` visibility logic
- drop `custom_appearance` checks from block components
- fallback to settings then common settings for all blocks
- clean up preview components to always apply css vars
- remove `custom_appearance` field from schemas

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684babd897088331ba97ef024c5d5817