### PR TITLE
Add unsaved changes alert when switching blocks

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
@@ -12,6 +12,7 @@ export default function PageEditor() {
   const [blocks, setBlocks] = useState([])
   const [blockDataMap, setBlockDataMap] = useState({})
   const [selectedId, setSelectedId] = useState(null)
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
   const API_URL = import.meta.env.VITE_API_URL
 
   useEffect(() => {
@@ -48,6 +49,7 @@ export default function PageEditor() {
       )
       return { ...prev, blocks: { ...prev.blocks, [slug]: updatedBlocks } }
     })
+    setHasUnsavedChanges(false)
     alert('Сохранено!')
   }
 
@@ -69,6 +71,18 @@ export default function PageEditor() {
     alert('Добавление нового блока')
   }
 
+  const handleSelectBlock = (id) => {
+    if (id === selectedId) return
+    if (hasUnsavedChanges) {
+      const confirmSwitch = window.confirm(
+        'Есть несохранённые изменения. Переключиться без сохранения?'
+      )
+      if (!confirmSwitch) return
+      setHasUnsavedChanges(false)
+    }
+    setSelectedId(id)
+  }
+
   if (loadingContext || !blocks.length || !data?.pages) return <div className="p-6">Загрузка...</div>
 
   const selectedBlock = blocks.find(b => b.id === selectedId)
@@ -81,7 +95,7 @@ export default function PageEditor() {
         <BlockListSidebar
           blocks={blocks}
           selectedId={selectedId}
-          setSelectedId={setSelectedId}
+          setSelectedId={handleSelectBlock}
           setBlocks={setBlocks}
           handleReorder={handleReorder}
           handleAddBlock={handleAddBlock}
@@ -90,6 +104,7 @@ export default function PageEditor() {
           selectedBlock={selectedBlock}
           selectedData={selectedData}
           onSave={handleSave}
+          setHasUnsavedChanges={setHasUnsavedChanges}
         />
       </div>
     </div>

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
@@ -1,12 +1,18 @@
 import BlockDetails from '@/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails'
 
-export default function BlockEditorPanel({ selectedBlock, selectedData, onSave }) {
+export default function BlockEditorPanel({
+  selectedBlock,
+  selectedData,
+  onSave,
+  setHasUnsavedChanges,
+}) {
   return (
     <div className="flex-1 border rounded p-4 bg-white shadow-sm min-h-[200px] overflow-x-auto">
       <BlockDetails
         block={selectedBlock}
         data={{ ...selectedData, block_id: selectedBlock?.real_id }}
         onSave={onSave}
+        setHasUnsavedChanges={setHasUnsavedChanges}
       />
     </div>
   )

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -18,7 +18,7 @@ import DeliveryEditor from '@blocks/forms/Delivery'
 import AboutCompanyEditor from '@blocks/forms/AboutCompany'
 import FooterEditor from '@blocks/forms/Footer'
 
-export default function BlockDetails({ block, data, onSave }) {
+export default function BlockDetails({ block, data, onSave, setHasUnsavedChanges }) {
   const [form, setForm] = useState({})
   const [showPreview, setShowPreview] = useState(true)
   const { slug } = useParams()
@@ -86,10 +86,15 @@ export default function BlockDetails({ block, data, onSave }) {
 
   const mergedBlock = { ...block, settings: form.settings, data: form.data }
 
+  const handleFormChange = (update) => {
+    setHasUnsavedChanges(true)
+    setForm(prev => (typeof update === 'function' ? update(prev) : { ...prev, ...update }))
+  }
+
   const sharedProps = {
     block: mergedBlock,
     data: form,
-    onChange: setForm,
+    onChange: handleFormChange,
     slug,
     site_name,
   }


### PR DESCRIPTION
## Summary
- add `hasUnsavedChanges` flag in `BlocksEditor`
- warn user about unsaved changes when switching blocks
- reset flag after saving block
- plumb unsaved-change setter through `BlockEditorPanel` and `BlockDetails`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c0ddfbc048331a56757a942d286d8