### PR TITLE
Implement global blocks saving

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
@@ -105,17 +105,7 @@ export default function TextEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showSaveButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showSaveButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
@@ -124,17 +124,7 @@ export default function BannerEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {canShow && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showAppearanceButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
@@ -104,17 +104,7 @@ export default function DeliveryEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showAppearanceButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showAppearanceButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
@@ -104,17 +104,7 @@ export default function FooterEditor({ block, data, onChange, slug }) {
         </>
       )}
 
-      {(showDataButton || showSaveButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showSaveButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
@@ -118,17 +118,7 @@ export default function HeaderEditor({ block, slug, onChange }) {
         />
       )}
 
-      {(showDataButton || showAppearanceButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showAppearanceButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/Editor.jsx
@@ -73,14 +73,7 @@ export default function TabsEditor({ block, data, onChange, slug }) {
         </>
       )}
 
-      {showSaveButton && (
-        <button
-          onClick={() => handleSaveAppearance(data)}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/Editor.jsx
@@ -86,14 +86,7 @@ export default function NavigationEditor({ block, data, onChange, slug }) {
         </>
       )}
 
-      {showSaveButton && (
-        <button
-          onClick={() => handleSaveAppearance(data)}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
@@ -106,17 +106,7 @@ export default function ProductsEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showAppearanceButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showAppearanceButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
 
 
     </div>

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/Editor.jsx
@@ -73,14 +73,7 @@ export default function ProductGridEditor({ block, data, onChange, slug }) {
         </>
       )}
 
-      {showSaveButton && (
-        <button
-          onClick={() => handleSaveAppearance(data)}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
@@ -108,17 +108,7 @@ export default function PromoEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showSaveButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showSaveButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
 
     </div>
   )

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
@@ -118,17 +118,7 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showAppearanceButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showAppearanceButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
@@ -106,17 +106,7 @@ export default function ReviewsEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showSaveButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showSaveButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Global save button now handles persistence */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
@@ -12,6 +12,7 @@ export default function PageEditor() {
   const [blocks, setBlocks] = useState([])
   const [blockDataMap, setBlockDataMap] = useState({})
   const [selectedId, setSelectedId] = useState(null)
+  const [unsavedBlocks, setUnsavedBlocks] = useState({})
   const API_URL = import.meta.env.VITE_API_URL
 
   useEffect(() => {
@@ -29,25 +30,45 @@ export default function PageEditor() {
     setBlockDataMap(map)
   }, [data, slug])
 
-  const handleSave = async (blockId, newData) => {
-    const res = await fetch(`${API_URL}/sites/${site_name}/pages/${slug}/blocks/${blockId}`, {
-      method: 'PATCH',
+  const handleBlockChange = (id, update) => {
+    setUnsavedBlocks(prev => ({ ...prev, [id]: update }))
+  }
+
+  const handleSaveAll = async () => {
+    const payload = Object.entries(unsavedBlocks).map(([block_id, changes]) => ({
+      block_id: Number(block_id),
+      ...(changes.settings ? { settings: changes.settings } : {}),
+      ...(changes.data ? { data: changes.data } : {}),
+    }))
+
+    if (payload.length === 0) return
+
+    const res = await fetch(`${API_URL}/blocks/update-all/${site_name}/${slug}`, {
+      method: 'POST',
       headers: {
         Authorization: `Bearer ${localStorage.getItem('access_token')}`,
         'Content-Type': 'application/json',
       },
       credentials: 'include',
-      body: JSON.stringify(newData),
+      body: JSON.stringify(payload),
     })
+
     if (!res.ok) return alert('Не удалось сохранить данные')
 
-    setBlockDataMap(prev => ({ ...prev, [blockId]: newData }))
     setData(prev => {
-      const updatedBlocks = prev.blocks?.[slug]?.map(b =>
-        b.real_id === blockId ? { ...b, settings: newData } : b
-      )
+      const updatedBlocks = prev.blocks?.[slug]?.map(b => {
+        const change = unsavedBlocks[b.real_id]
+        if (!change) return b
+        return {
+          ...b,
+          ...(change.settings ? { settings: change.settings } : {}),
+          ...(change.data ? { data: change.data } : {}),
+        }
+      })
       return { ...prev, blocks: { ...prev.blocks, [slug]: updatedBlocks } }
     })
+
+    setUnsavedBlocks({})
     alert('Сохранено!')
   }
 
@@ -72,11 +93,17 @@ export default function PageEditor() {
   if (loadingContext || !blocks.length || !data?.pages) return <div className="p-6">Загрузка...</div>
 
   const selectedBlock = blocks.find(b => b.id === selectedId)
-  const selectedData = selectedBlock ? blockDataMap[selectedBlock.real_id] || {} : {}
+  const selectedData =
+    selectedBlock ? unsavedBlocks[selectedBlock.real_id] || blockDataMap[selectedBlock.real_id] || {} : {}
 
   return (
     <div className="px-6 pt-0 space-y-4">
-      <PageSelectHeader slug={slug} data={data} />
+      <PageSelectHeader
+        slug={slug}
+        data={data}
+        hasUnsaved={Object.keys(unsavedBlocks).length > 0}
+        onSave={handleSaveAll}
+      />
       <div className="flex gap-6">
         <BlockListSidebar
           blocks={blocks}
@@ -89,7 +116,8 @@ export default function PageEditor() {
         <BlockEditorPanel
           selectedBlock={selectedBlock}
           selectedData={selectedData}
-          onSave={handleSave}
+          onSave={handleSaveAll}
+          onChange={handleBlockChange}
         />
       </div>
     </div>

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
@@ -1,12 +1,13 @@
 import BlockDetails from '@/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails'
 
-export default function BlockEditorPanel({ selectedBlock, selectedData, onSave }) {
+export default function BlockEditorPanel({ selectedBlock, selectedData, onSave, onChange }) {
   return (
     <div className="flex-1 border rounded p-4 bg-white shadow-sm min-h-[200px] overflow-x-auto">
       <BlockDetails
         block={selectedBlock}
         data={{ ...selectedData, block_id: selectedBlock?.real_id }}
         onSave={onSave}
+        onBlockChange={onChange}
       />
     </div>
   )

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/PageSelectHeader.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/PageSelectHeader.jsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate, Link } from 'react-router-dom'
 
-export default function PageSelectHeader({ slug, data }) {
+export default function PageSelectHeader({ slug, data, hasUnsaved, onSave }) {
   const { domain } = useParams()
   const navigate = useNavigate()
   const pageInfo = data?.pages?.find(p => p.slug === slug)
@@ -23,6 +23,14 @@ export default function PageSelectHeader({ slug, data }) {
         </select>
         {pageId && <span className="text-sm text-gray-500">ID страницы: {pageId}</span>}
       </div>
+      {hasUnsaved && (
+        <button
+          onClick={onSave}
+          className="bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
+        >
+          💾 Сохранить
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -18,7 +18,7 @@ import DeliveryEditor from '@blocks/forms/Delivery'
 import AboutCompanyEditor from '@blocks/forms/AboutCompany'
 import FooterEditor from '@blocks/forms/Footer'
 
-export default function BlockDetails({ block, data, onSave }) {
+export default function BlockDetails({ block, data, onSave, onBlockChange }) {
   const [form, setForm] = useState({})
   const [showPreview, setShowPreview] = useState(true)
   const { slug } = useParams()
@@ -86,10 +86,24 @@ export default function BlockDetails({ block, data, onSave }) {
 
   const mergedBlock = { ...block, settings: form.settings, data: form.data }
 
+  const handleChange = (update) => {
+    setForm(prev => {
+      const resolved =
+        typeof update === 'function' ? update(prev) : { ...prev, ...update }
+      if (onBlockChange && block?.real_id) {
+        onBlockChange(block.real_id, {
+          settings: resolved.settings,
+          data: resolved.data,
+        })
+      }
+      return resolved
+    })
+  }
+
   const sharedProps = {
     block: mergedBlock,
     data: form,
-    onChange: setForm,
+    onChange: handleChange,
     slug,
     site_name,
   }


### PR DESCRIPTION
## Summary
- add global save button for block editor pages
- collect unsaved block changes across editors
- send accumulated changes via `update-all` endpoint
- remove per-block save buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d8812d098833190a0f999b191767d