### PR TITLE
Add global save for page blocks

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/AboutCompany/Editor.jsx
@@ -105,17 +105,7 @@ export default function TextEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showSaveButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showSaveButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Banner/Editor.jsx
@@ -124,17 +124,7 @@ export default function BannerEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {canShow && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showAppearanceButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Editor.jsx
@@ -104,17 +104,7 @@ export default function DeliveryEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showAppearanceButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showAppearanceButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Footer/Editor.jsx
@@ -104,17 +104,7 @@ export default function FooterEditor({ block, data, onChange, slug }) {
         </>
       )}
 
-      {(showDataButton || showSaveButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showSaveButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Editor.jsx
@@ -118,17 +118,7 @@ export default function HeaderEditor({ block, slug, onChange }) {
         />
       )}
 
-      {(showDataButton || showAppearanceButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showAppearanceButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/MenuTabs/Editor.jsx
@@ -73,14 +73,7 @@ export default function TabsEditor({ block, data, onChange, slug }) {
         </>
       )}
 
-      {showSaveButton && (
-        <button
-          onClick={() => handleSaveAppearance(data)}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Navigation/Editor.jsx
@@ -86,14 +86,7 @@ export default function NavigationEditor({ block, data, onChange, slug }) {
         </>
       )}
 
-      {showSaveButton && (
-        <button
-          onClick={() => handleSaveAppearance(data)}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/Editor.jsx
@@ -106,17 +106,7 @@ export default function ProductsEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showAppearanceButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showAppearanceButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
 
 
     </div>

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/ProductGrid/Editor.jsx
@@ -73,14 +73,7 @@ export default function ProductGridEditor({ block, data, onChange, slug }) {
         </>
       )}
 
-      {showSaveButton && (
-        <button
-          onClick={() => handleSaveAppearance(data)}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/Editor.jsx
@@ -108,17 +108,7 @@ export default function PromoEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showSaveButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showSaveButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
 
     </div>
   )

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/QuickInfo/Editor.jsx
@@ -118,17 +118,7 @@ export default function QuickInfoEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showAppearanceButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showAppearanceButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Editor.jsx
@@ -106,17 +106,7 @@ export default function ReviewsEditor({ block, slug, onChange }) {
         </>
       )}
 
-      {(showDataButton || showSaveButton) && (
-        <button
-          onClick={() => {
-            if (showDataButton) handleSaveData(dataState)
-            if (showSaveButton) handleSaveAppearance(settingsState)
-          }}
-          className="fixed bottom-4 right-4 z-50 bg-emerald-600 text-white px-4 py-2 rounded hover:bg-emerald-700 transition text-sm"
-        >
-          💾 Сохранить
-        </button>
-      )}
+      {/* Кнопка сохранения убрана, общий "Сохранить" находится вверху страницы */}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/index.jsx
@@ -10,7 +10,8 @@ export default function PageEditor() {
   const { slug } = useParams()
   const { data, loading: loadingContext, site_name, setData } = useSiteSettings()
   const [blocks, setBlocks] = useState([])
-  const [blockDataMap, setBlockDataMap] = useState({})
+  const [drafts, setDrafts] = useState({})
+  const [initialDrafts, setInitialDrafts] = useState({})
   const [selectedId, setSelectedId] = useState(null)
   const API_URL = import.meta.env.VITE_API_URL
 
@@ -24,29 +25,60 @@ export default function PageEditor() {
 
     const map = {}
     for (const b of sortedBlocks) {
-      map[b.real_id] = typeof b.settings === 'string' ? JSON.parse(b.settings) : b.settings || {}
+      const settings = typeof b.settings === 'string' ? JSON.parse(b.settings) : b.settings || {}
+      const d = typeof b.data === 'string' ? JSON.parse(b.data) : b.data || {}
+      map[b.real_id] = { settings, data: d }
     }
-    setBlockDataMap(map)
+    setDrafts(map)
+    setInitialDrafts(map)
   }, [data, slug])
 
-  const handleSave = async (blockId, newData) => {
-    const res = await fetch(`${API_URL}/sites/${site_name}/pages/${slug}/blocks/${blockId}`, {
-      method: 'PATCH',
+  const handleBlockChange = (id, update) => {
+    setDrafts(prev => ({ ...prev, [id]: update }))
+  }
+
+  const handleSaveAll = async () => {
+    const payload = []
+    for (const [id, draft] of Object.entries(drafts)) {
+      const initial = initialDrafts[id] || {}
+      const changed = {}
+      if (JSON.stringify(draft.settings) !== JSON.stringify(initial.settings)) {
+        changed.settings = draft.settings
+      }
+      if (JSON.stringify(draft.data) !== JSON.stringify(initial.data)) {
+        changed.data = draft.data
+      }
+      if (Object.keys(changed).length) {
+        payload.push({ block_id: Number(id), ...changed })
+      }
+    }
+    if (!payload.length) return alert('Нет изменений для сохранения')
+
+    const res = await fetch(`${API_URL}/blocks/update-all/${site_name}/${slug}`, {
+      method: 'POST',
       headers: {
         Authorization: `Bearer ${localStorage.getItem('access_token')}`,
         'Content-Type': 'application/json',
       },
       credentials: 'include',
-      body: JSON.stringify(newData),
+      body: JSON.stringify(payload),
     })
     if (!res.ok) return alert('Не удалось сохранить данные')
 
-    setBlockDataMap(prev => ({ ...prev, [blockId]: newData }))
+    setInitialDrafts(drafts)
     setData(prev => {
-      const updatedBlocks = prev.blocks?.[slug]?.map(b =>
-        b.real_id === blockId ? { ...b, settings: newData } : b
-      )
-      return { ...prev, blocks: { ...prev.blocks, [slug]: updatedBlocks } }
+      const updated = prev.blocks?.[slug]?.map(b => {
+        const found = payload.find(p => p.block_id === b.real_id)
+        if (found) {
+          return {
+            ...b,
+            settings: found.settings ?? b.settings,
+            data: found.data ?? b.data,
+          }
+        }
+        return b
+      })
+      return { ...prev, blocks: { ...prev.blocks, [slug]: updated } }
     })
     alert('Сохранено!')
   }
@@ -72,11 +104,29 @@ export default function PageEditor() {
   if (loadingContext || !blocks.length || !data?.pages) return <div className="p-6">Загрузка...</div>
 
   const selectedBlock = blocks.find(b => b.id === selectedId)
-  const selectedData = selectedBlock ? blockDataMap[selectedBlock.real_id] || {} : {}
+  const selectedData = selectedBlock ? drafts[selectedBlock.real_id] || {} : {}
+
+  const hasUnsaved = Object.keys(drafts).some(id => {
+    const d = drafts[id] || {}
+    const i = initialDrafts[id] || {}
+    return (
+      JSON.stringify(d.settings) !== JSON.stringify(i.settings) ||
+      JSON.stringify(d.data) !== JSON.stringify(i.data)
+    )
+  })
 
   return (
     <div className="px-6 pt-0 space-y-4">
-      <PageSelectHeader slug={slug} data={data} />
+      <div className="flex justify-between items-center">
+        <PageSelectHeader slug={slug} data={data} />
+        <button
+          onClick={handleSaveAll}
+          disabled={!hasUnsaved}
+          className="bg-emerald-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        >
+          💾 Сохранить
+        </button>
+      </div>
       <div className="flex gap-6">
         <BlockListSidebar
           blocks={blocks}
@@ -89,7 +139,7 @@ export default function PageEditor() {
         <BlockEditorPanel
           selectedBlock={selectedBlock}
           selectedData={selectedData}
-          onSave={handleSave}
+          onChange={handleBlockChange}
         />
       </div>
     </div>

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/parts/BlockEditorPanel.jsx
@@ -1,12 +1,12 @@
 import BlockDetails from '@/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails'
 
-export default function BlockEditorPanel({ selectedBlock, selectedData, onSave }) {
+export default function BlockEditorPanel({ selectedBlock, selectedData, onChange }) {
   return (
     <div className="flex-1 border rounded p-4 bg-white shadow-sm min-h-[200px] overflow-x-auto">
       <BlockDetails
         block={selectedBlock}
         data={{ ...selectedData, block_id: selectedBlock?.real_id }}
-        onSave={onSave}
+        onChangeBlock={onChange}
       />
     </div>
   )

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -18,11 +18,21 @@ import DeliveryEditor from '@blocks/forms/Delivery'
 import AboutCompanyEditor from '@blocks/forms/AboutCompany'
 import FooterEditor from '@blocks/forms/Footer'
 
-export default function BlockDetails({ block, data, onSave }) {
+export default function BlockDetails({ block, data, onChangeBlock }) {
   const [form, setForm] = useState({})
   const [showPreview, setShowPreview] = useState(true)
   const { slug } = useParams()
   const { site_name, data: siteData } = useSiteSettings()
+
+  const handleFormChange = (update) => {
+    setForm(prev => {
+      const next = typeof update === 'function' ? update(prev) : update
+      if (onChangeBlock && block?.real_id) {
+        onChangeBlock(block.real_id, { settings: next.settings, data: next.data })
+      }
+      return next
+    })
+  }
 
   useEffect(() => {
     if (!block?.real_id) return
@@ -30,7 +40,7 @@ export default function BlockDetails({ block, data, onSave }) {
     const combinedSettings = { ...(data?.settings || data || {}), ...(block.settings || {}) }
     const combinedData = { ...(data?.data || {}), ...(block.data || {}) }
 
-    setForm({
+    const initial = {
       ...combinedSettings,
       ...combinedData,
       data: { ...combinedData },
@@ -42,7 +52,11 @@ export default function BlockDetails({ block, data, onSave }) {
       order: block.order,
       active: block.active,
       label: block.label,
-    })
+    }
+    setForm(initial)
+    if (onChangeBlock) {
+      onChangeBlock(block.real_id, { settings: initial.settings, data: initial.data })
+    }
   }, [block, data])
 
   if (!block || !block.real_id) {
@@ -89,7 +103,7 @@ export default function BlockDetails({ block, data, onSave }) {
   const sharedProps = {
     block: mergedBlock,
     data: form,
-    onChange: setForm,
+    onChange: handleFormChange,
     slug,
     site_name,
   }


### PR DESCRIPTION
## Summary
- consolidate unsaved changes in `PageEditor`
- add single save button for all blocks
- propagate block edits up to parent
- remove per-block save buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d8812d098833190a0f999b191767d