### PR TITLE
Add products management module

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.3",
@@ -24,7 +25,12 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.1",
     "tailwind-merge": "^3.2.0",
-    "tailwind-variants": "^1.0.0"
+    "tailwind-variants": "^1.0.0",
+    "@tanstack/react-query": "^5.29.0",
+    "@tanstack/react-query-devtools": "^5.29.0",
+    "react-hook-form": "^7.51.3",
+    "zod": "^3.22.4",
+    "@hookform/resolvers": "^3.3.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
@@ -40,6 +46,10 @@
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
-    "vite": "^6.3.1"
+    "vite": "^6.3.1",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/jest-dom": "^6.2.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+// FILE: src/App.jsx
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Login from './pages/Login'
 import Dashboard from './pages/Dashboard'
@@ -11,16 +12,20 @@ import Products from './pages/Sites/SiteSettings/Products'
 import Integrations from './pages/Sites/SiteSettings/Integrations'
 import GeneralSettings from './pages/Sites/SiteSettings/GeneralSettings'
 import { SiteSettingsProvider } from './context/SiteSettingsContext'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 export default function App() {
+  const queryClient = new QueryClient()
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="/" element={<MainLayout />}>
-          <Route index element={<Dashboard />} />
-          <Route path="sites" element={<Sites />} />
-          <Route path="users" element={<Users />} />
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/" element={<MainLayout />}>
+            <Route index element={<Dashboard />} />
+            <Route path="sites" element={<Sites />} />
+            <Route path="users" element={<Users />} />
 
           {/* Обёртка для всех настроек сайта */}
           <Route
@@ -39,6 +44,8 @@ export default function App() {
           </Route>
         </Route>
       </Routes>
-    </BrowserRouter>
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+      </BrowserRouter>
+    </QueryClientProvider>
   )
 }

--- a/src/pages/Sites/SiteSettings/Products/components/CategoryTree/index.tsx
+++ b/src/pages/Sites/SiteSettings/Products/components/CategoryTree/index.tsx
@@ -1,0 +1,37 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/CategoryTree/index.tsx
+import { useState } from 'react'
+import { useCategories } from '../../hooks/useCategories'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  site: string
+  onSelect: (code?: string) => void
+}
+
+export default function CategoryTree({ site, onSelect }: Props) {
+  const { data } = useCategories(site)
+  const [active, setActive] = useState<string>()
+
+  const handleSelect = (code?: string) => {
+    setActive(code)
+    onSelect(code)
+  }
+
+  return (
+    <div className="p-4 space-y-2">
+      <Button className="w-full" onClick={() => handleSelect(undefined)}>
+        Все категории
+      </Button>
+      {data?.map((c) => (
+        <Button
+          key={c.code}
+          variant={active === c.code ? undefined : 'secondary'}
+          className="w-full justify-start"
+          onClick={() => handleSelect(c.code)}
+        >
+          {c.name}
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/EmptyState.tsx
+++ b/src/pages/Sites/SiteSettings/Products/components/EmptyState.tsx
@@ -1,0 +1,11 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/EmptyState.tsx
+import { Button } from '@/components/ui/button'
+
+export default function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center text-center p-8">
+      <p className="mb-4 text-gray-500">Товаров пока нет</p>
+      <Button onClick={onAdd}>Добавить первый товар</Button>
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductForm/index.tsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductForm/index.tsx
@@ -1,0 +1,44 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/ProductForm/index.tsx
+import { Dialog } from '@headlessui/react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+const schema = z.object({
+  title: z.string().min(1),
+  price: z.number().min(0),
+})
+
+type FormData = z.infer<typeof schema>
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onSubmit: (data: FormData) => void
+}
+
+export default function ProductForm({ open, onClose, onSubmit }: Props) {
+  const { register, handleSubmit, formState } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  })
+
+  return (
+    <Dialog open={open} onClose={onClose} className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="bg-white dark:bg-black p-4 rounded space-y-2 w-80">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+          <Input placeholder="Название" {...register('title')} />
+          <Input type="number" placeholder="Цена" {...register('price', { valueAsNumber: true })} />
+          {formState.errors.title && <p className="text-red-500 text-sm">Требуется название</p>}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="secondary" onClick={onClose}>
+              Отмена
+            </Button>
+            <Button type="submit">Сохранить</Button>
+          </div>
+        </form>
+      </div>
+    </Dialog>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsTable/index.tsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsTable/index.tsx
@@ -1,0 +1,27 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/ProductsTable/index.tsx
+import type { Product } from '@/types/products'
+
+interface Props {
+  products: Product[]
+}
+
+export default function ProductsTable({ products }: Props) {
+  return (
+    <table className="min-w-full text-sm">
+      <thead>
+        <tr>
+          <th className="p-2 text-left">Название</th>
+          <th className="p-2 text-left">Цена</th>
+        </tr>
+      </thead>
+      <tbody>
+        {products.map((p) => (
+          <tr key={p.id} className="border-t">
+            <td className="p-2">{p.title}</td>
+            <td className="p-2">{p.price}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/SkeletonTable.tsx
+++ b/src/pages/Sites/SiteSettings/Products/components/SkeletonTable.tsx
@@ -1,0 +1,6 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/SkeletonTable.tsx
+export default function SkeletonTable() {
+  return (
+    <div className="p-4 animate-pulse text-gray-400">Загрузка...</div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/Toolbar.tsx
+++ b/src/pages/Sites/SiteSettings/Products/components/Toolbar.tsx
@@ -1,0 +1,35 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/Toolbar.tsx
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { useState, useRef } from 'react'
+
+function useDebounce(callback: (v: string) => void, delay: number) {
+  const timer = useRef<number>()
+  return (value: string) => {
+    window.clearTimeout(timer.current)
+    timer.current = window.setTimeout(() => callback(value), delay)
+  }
+}
+
+interface Props {
+  onAdd: () => void
+  onSearch: (value: string) => void
+  activeOnly: boolean
+}
+
+export default function Toolbar({ onAdd, onSearch }: Props) {
+  const [value, setValue] = useState('')
+
+  const debounced = useDebounce(onSearch, 300)
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value)
+    debounced(e.target.value)
+  }
+
+  return (
+    <div className="p-4 flex gap-2 items-center border-b">
+      <Button onClick={onAdd}>+ Новый товар</Button>
+      <Input value={value} onChange={handleChange} placeholder="Поиск" />
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/hooks/__tests__/useCategories.test.ts
+++ b/src/pages/Sites/SiteSettings/Products/hooks/__tests__/useCategories.test.ts
@@ -1,0 +1,14 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/__tests__/useCategories.test.ts
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useCategories } from '../useCategories'
+
+describe('useCategories', () => {
+  test('should fetch categories', async () => {
+    const qc = new QueryClient()
+    const wrapper = ({ children }: any) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    )
+    renderHook(() => useCategories('test'), { wrapper })
+  })
+})

--- a/src/pages/Sites/SiteSettings/Products/hooks/__tests__/useProductMutations.test.ts
+++ b/src/pages/Sites/SiteSettings/Products/hooks/__tests__/useProductMutations.test.ts
@@ -1,0 +1,15 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/__tests__/useProductMutations.test.ts
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useProductMutations } from '../useProductMutations'
+
+describe('useProductMutations', () => {
+  test('should provide mutation functions', () => {
+    const qc = new QueryClient()
+    const wrapper = ({ children }: any) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(() => useProductMutations('test'), { wrapper })
+    expect(result.current).toBeTruthy()
+  })
+})

--- a/src/pages/Sites/SiteSettings/Products/hooks/__tests__/useProducts.test.ts
+++ b/src/pages/Sites/SiteSettings/Products/hooks/__tests__/useProducts.test.ts
@@ -1,0 +1,16 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/__tests__/useProducts.test.ts
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useProducts } from '../useProducts'
+
+const filters = { page: 1, limit: 20 }
+
+describe('useProducts', () => {
+  test('should fetch products', async () => {
+    const qc = new QueryClient()
+    const wrapper = ({ children }: any) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    )
+    renderHook(() => useProducts('test', filters), { wrapper })
+  })
+})

--- a/src/pages/Sites/SiteSettings/Products/hooks/useCategories.ts
+++ b/src/pages/Sites/SiteSettings/Products/hooks/useCategories.ts
@@ -1,0 +1,11 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/useCategories.ts
+import { useQuery } from '@tanstack/react-query'
+import { getCategories } from '@/services/products'
+import type { Category } from '@/types/products'
+
+export const useCategories = (site: string) => {
+  return useQuery<Category[]>({
+    queryKey: ['categories', site],
+    queryFn: () => getCategories(site),
+  })
+}

--- a/src/pages/Sites/SiteSettings/Products/hooks/useProductMutations.ts
+++ b/src/pages/Sites/SiteSettings/Products/hooks/useProductMutations.ts
@@ -1,0 +1,57 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/useProductMutations.ts
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  addCategory,
+  updateCategory,
+  deleteCategory,
+  addProduct,
+  updateProduct,
+  deleteProduct,
+} from '@/services/products'
+import type { CategoryDTO, ProductDTO } from '@/types/products'
+
+export const useProductMutations = (site: string) => {
+  const qc = useQueryClient()
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['categories', site] })
+    qc.invalidateQueries({ queryKey: ['products', site] })
+  }
+
+  const addCat = useMutation({
+    mutationFn: (data: CategoryDTO) => addCategory(site, data),
+    onSuccess: invalidate,
+  })
+  const updateCat = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: Partial<CategoryDTO> }) =>
+      updateCategory(site, id, data),
+    onSuccess: invalidate,
+  })
+  const deleteCat = useMutation({
+    mutationFn: (id: number) => deleteCategory(site, id),
+    onSuccess: invalidate,
+  })
+
+  const addProd = useMutation({
+    mutationFn: (data: ProductDTO) => addProduct(site, data),
+    onSuccess: invalidate,
+  })
+  const updateProd = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: Partial<ProductDTO> }) =>
+      updateProduct(site, id, data),
+    onSuccess: invalidate,
+  })
+  const deleteProd = useMutation({
+    mutationFn: (id: number) => deleteProduct(site, id),
+    onSuccess: invalidate,
+  })
+
+  return {
+    addCategory: addCat.mutateAsync,
+    updateCategory: updateCat.mutateAsync,
+    deleteCategory: deleteCat.mutateAsync,
+    addProduct: addProd.mutateAsync,
+    updateProduct: updateProd.mutateAsync,
+    deleteProduct: deleteProd.mutateAsync,
+  }
+}

--- a/src/pages/Sites/SiteSettings/Products/hooks/useProducts.ts
+++ b/src/pages/Sites/SiteSettings/Products/hooks/useProducts.ts
@@ -1,0 +1,12 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/useProducts.ts
+import { useQuery } from '@tanstack/react-query'
+import { getProducts, ProductFilters } from '@/services/products'
+import type { Paginated, Product } from '@/types/products'
+
+export const useProducts = (site: string, filters: ProductFilters) => {
+  return useQuery<Paginated<Product>>({
+    queryKey: ['products', site, filters],
+    queryFn: () => getProducts(site, filters),
+    keepPreviousData: true,
+  })
+}

--- a/src/pages/Sites/SiteSettings/Products/index.tsx
+++ b/src/pages/Sites/SiteSettings/Products/index.tsx
@@ -1,0 +1,43 @@
+// FILE: src/pages/Sites/SiteSettings/Products/index.tsx
+import { useState } from 'react'
+import { useParams } from 'react-router-dom'
+import CategoryTree from './components/CategoryTree'
+import ProductsTable from './components/ProductsTable'
+import Toolbar from './components/Toolbar'
+import ProductForm from './components/ProductForm'
+import EmptyState from './components/EmptyState'
+import SkeletonTable from './components/SkeletonTable'
+import { useProducts } from './hooks/useProducts'
+
+export default function Products() {
+  const { domain } = useParams()
+  const site_name = domain ?? ''
+  const [category, setCategory] = useState<string>()
+  const [search, setSearch] = useState('')
+  const [page, setPage] = useState(1)
+  const limit = 20
+  const [formOpen, setFormOpen] = useState(false)
+  const [activeOnly] = useState(false)
+
+  const filters = { category, search, page, limit, activeOnly }
+  const { data, isLoading } = useProducts(site_name, filters)
+
+  return (
+    <div className="flex h-full">
+      <aside className="w-1/4 border-r">
+        <CategoryTree site={site_name} onSelect={setCategory} />
+      </aside>
+      <section className="flex-1 flex flex-col overflow-hidden">
+        <Toolbar onAdd={() => setFormOpen(true)} onSearch={setSearch} activeOnly={activeOnly} />
+        {isLoading ? (
+          <SkeletonTable />
+        ) : data && data.results.length ? (
+          <ProductsTable products={data.results} />
+        ) : (
+          <EmptyState onAdd={() => setFormOpen(true)} />
+        )}
+      </section>
+      <ProductForm open={formOpen} onClose={() => setFormOpen(false)} onSubmit={() => setFormOpen(false)} />
+    </div>
+  )
+}

--- a/src/services/products.ts
+++ b/src/services/products.ts
@@ -1,0 +1,66 @@
+// FILE: src/services/products.ts
+import api from '@/lib/axios'
+import { CategoryDTO, Category, ProductDTO, Product, Paginated } from '@/types/products'
+
+const API_URL = import.meta.env.VITE_API_URL
+
+function url(site: string, suffix = '') {
+  return `${API_URL}/products/${site}${suffix}`
+}
+
+// Categories
+export const getCategories = async (site: string): Promise<Category[]> => {
+  const res = await api.get(url(site, '/categories/all'))
+  return res.data
+}
+
+export const addCategory = async (site: string, data: CategoryDTO): Promise<Category> => {
+  const res = await api.post(url(site, '/categories/add'), data)
+  return res.data
+}
+
+export const updateCategory = async (site: string, id: number, data: Partial<CategoryDTO>): Promise<Category> => {
+  const res = await api.patch(url(site, `/categories/update/${id}`), data)
+  return res.data
+}
+
+export const deleteCategory = async (site: string, id: number): Promise<{ ok: boolean }> => {
+  const res = await api.delete(url(site, `/categories/delete/${id}`))
+  return res.data
+}
+
+// Products
+export interface ProductFilters {
+  category?: string
+  search?: string
+  page?: number
+  limit?: number
+  activeOnly?: boolean
+}
+
+export const getProducts = async (site: string, filters: ProductFilters): Promise<Paginated<Product>> => {
+  const params = new URLSearchParams()
+  if (filters.category) params.set('category', filters.category)
+  if (filters.search) params.set('search', filters.search)
+  if (filters.page) params.set('page', String(filters.page))
+  if (filters.limit) params.set('limit', String(filters.limit))
+  if (filters.activeOnly) params.set('activeOnly', 'true')
+
+  const res = await api.get(url(site, `/all?${params.toString()}`))
+  return res.data
+}
+
+export const addProduct = async (site: string, data: ProductDTO): Promise<Product> => {
+  const res = await api.post(url(site, '/add'), data)
+  return res.data
+}
+
+export const updateProduct = async (site: string, id: number, data: Partial<ProductDTO>): Promise<Product> => {
+  const res = await api.patch(url(site, `/update/${id}`), data)
+  return res.data
+}
+
+export const deleteProduct = async (site: string, id: number): Promise<{ ok: boolean }> => {
+  const res = await api.delete(url(site, `/delete/${id}`))
+  return res.data
+}

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -1,0 +1,52 @@
+// FILE: src/types/products.ts
+export interface CategoryDTO {
+  code: string
+  name: string
+  description?: string
+  image_url?: string
+  display_order?: number
+  is_active?: boolean
+}
+
+export interface Category extends CategoryDTO {
+  id: number
+  created_at: string
+  updated_at: string
+}
+
+export interface ProductDTO {
+  title: string
+  slug: string
+  price: number
+  old_price?: number
+  currency?: string
+  description?: string
+  full_description?: string
+  image_url?: string
+  gallery?: string[]
+  is_available?: boolean
+  category_id?: string
+  labels?: string[]
+  rating?: number
+  rating_count?: number
+  weight?: string
+  props?: Record<string, string>
+  extras?: unknown[]
+  related_product_ids?: number[]
+  custom_data?: Record<string, any>
+  order?: number
+  active?: boolean
+}
+
+export interface Product extends ProductDTO {
+  id: number
+  created_at: string
+  updated_at: string
+}
+
+export interface Paginated<T> {
+  results: T[]
+  total: number
+  page: number
+  limit: number
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+// FILE: vitest.config.ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary
- add TypeScript configuration and vitest setup
- extend dependencies for react-query and forms
- wrap app with `QueryClientProvider` and devtools
- implement products API service and types
- create hooks with React Query
- scaffold Products page with CategoryTree and table
- supply basic hook unit test templates

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501452dfcc83319ac0387516da2138