### PR TITLE
Add products module skeleton

### DIFF
--- a/src/components/ui/sheet.jsx
+++ b/src/components/ui/sheet.jsx
@@ -1,0 +1,18 @@
+// FILE: src/components/ui/sheet.jsx
+import * as React from 'react'
+
+export function Sheet({ children, open, onOpenChange }) {
+  return <div>{open ? children : null}</div>
+}
+
+export function SheetTrigger({ children, ...props }) {
+  return <button {...props}>{children}</button>
+}
+
+export function SheetContent({ children, className }) {
+  return (
+    <div className={className} style={{ position: 'fixed', inset: 0, background: 'white', zIndex: 50 }}>
+      {children}
+    </div>
+  )
+}

--- a/src/lib/http.js
+++ b/src/lib/http.js
@@ -1,0 +1,29 @@
+// FILE: src/lib/http.js
+import { authFetch } from './authFetch'
+
+const json = async (res) => {
+  if (!res.ok) throw new Error('HTTP error ' + res.status)
+  return res.json()
+}
+
+export const get = (url, params) => {
+  const search = params ? '?' + new URLSearchParams(params).toString() : ''
+  return authFetch(url + search).then(json)
+}
+
+export const post = (url, body) =>
+  authFetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }).then(json)
+
+export const patch = (url, body) =>
+  authFetch(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }).then(json)
+
+export const del = (url) =>
+  authFetch(url, { method: 'DELETE' }).then(json)

--- a/src/pages/Sites/SiteSettings/Products/components/CategoryTree/index.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/CategoryTree/index.jsx
@@ -1,0 +1,51 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/CategoryTree/index.jsx
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Sheet, SheetTrigger, SheetContent } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { useCategories, useProductMutations } from '../../hooks'
+
+const schema = z.object({
+  code: z.string().min(1),
+  name: z.string().min(1),
+})
+
+export default function CategoryTree({ site }) {
+  const { data: categories = [] } = useCategories(site)
+  const { addCategory } = useProductMutations(site)
+  const [open, setOpen] = useState(false)
+  const form = useForm({ resolver: zodResolver(schema), defaultValues: { code: '', name: '' } })
+
+  const onSubmit = async (values) => {
+    await addCategory(values)
+    form.reset()
+  }
+
+  const content = (
+    <div className="p-4 space-y-4 w-64">
+      <h3 className="font-semibold">Категории</h3>
+      <ul className="space-y-1 text-sm">
+        {categories.map((c) => (
+          <li key={c.id}>{c.name}</li>
+        ))}
+      </ul>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-2">
+        <input placeholder="code" {...form.register('code')} className="border rounded px-2 py-1 w-full" />
+        <input placeholder="name" {...form.register('name')} className="border rounded px-2 py-1 w-full" />
+        <Button type="submit" className="w-full">Добавить</Button>
+      </form>
+    </div>
+  )
+
+  return (
+    <>
+      <div className="lg:block hidden border-r">{content}</div>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger className="lg:hidden px-4 py-2 border">Категории</SheetTrigger>
+        <SheetContent className="p-0">{content}</SheetContent>
+      </Sheet>
+    </>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/EmptyState.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/EmptyState.jsx
@@ -1,0 +1,11 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/EmptyState.jsx
+import { Button } from '@/components/ui/button'
+
+export default function EmptyState({ onAdd }) {
+  return (
+    <div className="text-center py-20 space-y-4">
+      <p className="text-gray-500">Товары не найдены</p>
+      <Button onClick={onAdd} className="bg-blue-600 text-white">Добавить первый товар</Button>
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductForm/index.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductForm/index.jsx
@@ -1,0 +1,40 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/ProductForm/index.jsx
+import { useState } from 'react'
+import { Dialog } from '@headlessui/react'
+import { useForm } from 'react-hook-form'
+import { Button } from '@/components/ui/button'
+import { useProductMutations } from '../../hooks'
+
+export default function ProductForm({ site, open, onOpenChange }) {
+  const { addProduct } = useProductMutations(site)
+  const form = useForm({ defaultValues: { title: '', price: 0 } })
+  const [step, setStep] = useState(0)
+
+  const submit = async (values) => {
+    await addProduct(values)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onClose={() => onOpenChange(false)} className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white p-6 rounded space-y-4 w-96">
+        <h2 className="font-semibold text-lg">Новый товар</h2>
+        {step === 0 && (
+          <div className="space-y-2">
+            <input placeholder="Название" {...form.register('title')} className="border rounded px-2 py-1 w-full" />
+            <Button onClick={() => setStep(1)} className="w-full">Далее</Button>
+          </div>
+        )}
+        {step === 1 && (
+          <form onSubmit={form.handleSubmit(submit)} className="space-y-2">
+            <input type="number" placeholder="Цена" {...form.register('price', { valueAsNumber: true })} className="border rounded px-2 py-1 w-full" />
+            <div className="flex justify-end gap-2">
+              <Button type="button" onClick={() => setStep(0)}>Назад</Button>
+              <Button type="submit" className="bg-blue-600 text-white">Создать</Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </Dialog>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsTable/index.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsTable/index.jsx
@@ -1,0 +1,28 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/ProductsTable/index.jsx
+import { useProducts } from '../../hooks'
+
+export default function ProductsTable({ site, filters }) {
+  const { data } = useProducts(site, filters)
+  const products = data?.results || []
+
+  if (!products.length) return null
+
+  return (
+    <table className="min-w-full text-sm border">
+      <thead>
+        <tr className="bg-gray-100">
+          <th className="p-2 text-left">Название</th>
+          <th className="p-2 text-left">Цена</th>
+        </tr>
+      </thead>
+      <tbody>
+        {products.map((p) => (
+          <tr key={p.id} className="border-t">
+            <td className="p-2">{p.title}</td>
+            <td className="p-2">{p.price}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/Toolbar.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/Toolbar.jsx
@@ -1,0 +1,24 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/Toolbar.jsx
+import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+
+export default function Toolbar({ onAdd, onSearch }) {
+  const [query, setQuery] = useState('')
+
+  useEffect(() => {
+    const id = setTimeout(() => onSearch(query), 300)
+    return () => clearTimeout(id)
+  }, [query, onSearch])
+
+  return (
+    <div className="flex justify-between items-center mb-4 gap-2 flex-wrap">
+      <Button onClick={onAdd} className="bg-blue-600 text-white px-4 py-2 rounded">+ Новый товар</Button>
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Поиск..."
+        className="border px-2 py-1 rounded"
+      />
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/hooks/__tests__/hooks.test.js
+++ b/src/pages/Sites/SiteSettings/Products/hooks/__tests__/hooks.test.js
@@ -1,0 +1,10 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/__tests__/hooks.test.js
+import { describe, it, expect } from 'vitest'
+
+// TODO: add tests for hooks using renderHook from @testing-library/react
+
+describe('product hooks', () => {
+  it('should be defined', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/src/pages/Sites/SiteSettings/Products/hooks/index.js
+++ b/src/pages/Sites/SiteSettings/Products/hooks/index.js
@@ -1,0 +1,4 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/index.js
+export * from './useCategories'
+export * from './useProducts'
+export * from './useProductMutations'

--- a/src/pages/Sites/SiteSettings/Products/hooks/useCategories.js
+++ b/src/pages/Sites/SiteSettings/Products/hooks/useCategories.js
@@ -1,0 +1,11 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/useCategories.js
+import { useQuery } from '@tanstack/react-query'
+import { getCategories } from '@/services/products'
+
+export function useCategories(site) {
+  return useQuery({
+    queryKey: ['categories', site],
+    queryFn: () => getCategories(site),
+    enabled: !!site,
+  })
+}

--- a/src/pages/Sites/SiteSettings/Products/hooks/useProductMutations.js
+++ b/src/pages/Sites/SiteSettings/Products/hooks/useProductMutations.js
@@ -1,0 +1,58 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/useProductMutations.js
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  addCategory,
+  updateCategory,
+  deleteCategory,
+  addProduct,
+  updateProduct,
+  deleteProduct,
+} from '@/services/products'
+
+export function useProductMutations(site) {
+  const qc = useQueryClient()
+
+  const invalidate = () => {
+    qc.invalidateQueries(['categories', site])
+    qc.invalidateQueries(['products', site])
+  }
+
+  const addCat = useMutation({
+    mutationFn: (dto) => addCategory(site, dto),
+    onSuccess: invalidate,
+  })
+
+  const updateCat = useMutation({
+    mutationFn: ({ id, dto }) => updateCategory(site, id, dto),
+    onSuccess: invalidate,
+  })
+
+  const deleteCatM = useMutation({
+    mutationFn: (id) => deleteCategory(site, id),
+    onSuccess: invalidate,
+  })
+
+  const addProd = useMutation({
+    mutationFn: (dto) => addProduct(site, dto),
+    onSuccess: invalidate,
+  })
+
+  const updateProd = useMutation({
+    mutationFn: ({ id, dto }) => updateProduct(site, id, dto),
+    onSuccess: invalidate,
+  })
+
+  const deleteProdM = useMutation({
+    mutationFn: (id) => deleteProduct(site, id),
+    onSuccess: invalidate,
+  })
+
+  return {
+    addCategory: addCat.mutateAsync,
+    updateCategory: updateCat.mutateAsync,
+    deleteCategory: deleteCatM.mutateAsync,
+    addProduct: addProd.mutateAsync,
+    updateProduct: updateProd.mutateAsync,
+    deleteProduct: deleteProdM.mutateAsync,
+  }
+}

--- a/src/pages/Sites/SiteSettings/Products/hooks/useProducts.js
+++ b/src/pages/Sites/SiteSettings/Products/hooks/useProducts.js
@@ -1,0 +1,11 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/useProducts.js
+import { useQuery } from '@tanstack/react-query'
+import { getProducts } from '@/services/products'
+
+export function useProducts(site, filters) {
+  return useQuery({
+    queryKey: ['products', site, filters],
+    queryFn: () => getProducts(site, filters),
+    enabled: !!site,
+  })
+}

--- a/src/pages/Sites/SiteSettings/Products/index.jsx
+++ b/src/pages/Sites/SiteSettings/Products/index.jsx
@@ -1,8 +1,45 @@
+// FILE: src/pages/Sites/SiteSettings/Products/index.jsx
+import { useState, useRef } from 'react'
+import { useParams } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import CategoryTree from './components/CategoryTree'
+import ProductsTable from './components/ProductsTable'
+import Toolbar from './components/Toolbar'
+import ProductForm from './components/ProductForm'
+import EmptyState from './components/EmptyState'
+import { useProducts } from './hooks'
+
 export default function Products() {
-  return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">Товары</h1>
-      <p className="text-gray-600">Скоро здесь появится каталог товаров.</p>
+  const { domain } = useParams()
+  const site_name = domain ?? ''
+  const clientRef = useRef(new QueryClient())
+  const [open, setOpen] = useState(false)
+  const [filters, setFilters] = useState({ search: '' })
+  const { data } = useProducts(site_name, filters)
+  const hasProducts = (data?.results || []).length > 0
+
+  const handleSearch = (q) => setFilters((f) => ({ ...f, search: q }))
+
+  const page = (
+    <div className="flex gap-4">
+      <CategoryTree site={site_name} />
+      <div className="flex-1 space-y-4">
+        <Toolbar onAdd={() => setOpen(true)} onSearch={handleSearch} />
+        {hasProducts ? (
+          <ProductsTable site={site_name} filters={filters} />
+        ) : (
+          <EmptyState onAdd={() => setOpen(true)} />
+        )}
+      </div>
+      <ProductForm site={site_name} open={open} onOpenChange={setOpen} />
     </div>
+  )
+
+  return (
+    <QueryClientProvider client={clientRef.current}>
+      {page}
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
   )
 }

--- a/src/services/products.js
+++ b/src/services/products.js
@@ -1,0 +1,17 @@
+// FILE: src/services/products.js
+import { get, post, patch, del } from '@/lib/http'
+
+const API_URL = import.meta.env.VITE_API_URL
+const url = (site, suffix = '') => `${API_URL}/products/${site}${suffix}`
+
+// Categories
+export const getCategories = (site) => get(url(site, '/categories/all'))
+export const addCategory = (site, dto) => post(url(site, '/categories/add'), dto)
+export const updateCategory = (site, id, dto) => patch(url(site, `/categories/update/${id}`), dto)
+export const deleteCategory = (site, id) => del(url(site, `/categories/delete/${id}`))
+
+// Products
+export const getProducts = (site, params) => get(url(site, '/all'), params)
+export const addProduct = (site, dto) => post(url(site, '/add'), dto)
+export const updateProduct = (site, id, dto) => patch(url(site, `/update/${id}`), dto)
+export const deleteProduct = (site, id) => del(url(site, `/delete/${id}`))

--- a/src/types/products.js
+++ b/src/types/products.js
@@ -1,0 +1,49 @@
+// FILE: src/types/products.js
+
+/**
+ * @typedef {Object} CategoryDTO
+ * @property {string} code
+ * @property {string} name
+ * @property {string=} description
+ * @property {string=} image_url
+ * @property {number=} display_order
+ * @property {boolean=} is_active
+ */
+
+/**
+ * @typedef {CategoryDTO & {
+ *   id: number,
+ *   created_at: string,
+ *   updated_at: string
+ * }} Category
+ */
+
+/**
+ * @typedef {Object} ProductDTO
+ * @property {string} title
+ * @property {string} slug
+ * @property {number} price
+ * @property {number=} old_price
+ * @property {string=} description
+ * @property {number=} category_id
+ * @property {string=} image_url
+ * @property {boolean=} is_active
+ */
+
+/**
+ * @typedef {ProductDTO & {
+ *   id: number,
+ *   created_at: string,
+ *   updated_at: string
+ * }} Product
+ */
+
+/**
+ * @template T
+ * @typedef {Object} Paginated
+ * @property {T[]} results
+ * @property {number} total
+ * @property {number} page
+ * @property {number} limit
+ */
+

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,10 @@
+// FILE: vitest.config.js
+import { defineConfig } from 'vitest/config'
+import viteConfig from './vite.config.js'
+
+export default defineConfig({
+  ...viteConfig,
+  test: {
+    environment: 'jsdom',
+  },
+})


### PR DESCRIPTION
## Summary
- implement product and category types
- add http wrapper and products service
- create React Query hooks for products module
- build placeholder components (CategoryTree, ProductsTable, Toolbar, ProductForm, EmptyState)
- add Products page using Query Client
- add minimal sheet UI component
- add vitest config and test template

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68501a195ac483319bd916617d892128