### PR TITLE
Implement products list CRUD

### DIFF
--- a/src/pages/Sites/SiteSettings/Products/components/AddProductModal.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/AddProductModal.jsx
@@ -85,7 +85,7 @@ export default function AddProductModal({ open, onClose, onSave, categoryId }) {
       image_url: imageUrl || undefined,
       description: description.trim() || undefined,
       weight: w || undefined,
-      category_id: cId,
+      category_id: String(cId),
       active,
     }
 

--- a/src/pages/Sites/SiteSettings/Products/components/AddProductModal.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/AddProductModal.jsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function AddProductModal({ open, onClose, onSave, categoryId }) {
+  const [title, setTitle] = useState('')
+  const [price, setPrice] = useState('')
+
+  useEffect(() => {
+    if (!open) {
+      setTitle('')
+      setPrice('')
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const handleSave = () => {
+    const t = title.trim()
+    const p = parseFloat(price)
+    if (!t || isNaN(p)) return
+    onSave({ title: t, price: p, category_id: categoryId })
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Новый товар</h3>
+
+        <label className="mb-1 block text-sm">Название</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Введите название"
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="mb-1 block text-sm">Цена</label>
+        <input
+          type="number"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!title.trim() || !price}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Сохранить
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/AddProductModal.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/AddProductModal.jsx
@@ -1,5 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { createPortal } from 'react-dom'
+import { useParams } from 'react-router-dom'
+
+import { useCategories } from '../hooks/useCategories'
 
 const modalRoot =
   document.getElementById('modal-root') ||
@@ -11,23 +14,60 @@ const modalRoot =
   })()
 
 export default function AddProductModal({ open, onClose, onSave, categoryId }) {
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
+
+  const { data: tree = [] } = useCategories(siteName)
+
+  const categories = useMemo(() => {
+    const list = []
+    const walk = (nodes, prefix = '') =>
+      nodes.forEach((n) => {
+        const path = prefix ? `${prefix} / ${n.name}` : n.name
+        list.push({ id: n.id, path })
+        if (n.children?.length) walk(n.children, path)
+      })
+    walk(tree)
+    return list
+  }, [tree])
+
   const [title, setTitle] = useState('')
   const [price, setPrice] = useState('')
+  const [imageUrl, setImageUrl] = useState('')
+  const [description, setDescription] = useState('')
+  const [weight, setWeight] = useState('')
+  const [category, setCategory] = useState('')
+  const [active, setActive] = useState(true)
 
   useEffect(() => {
     if (!open) {
       setTitle('')
       setPrice('')
+      setImageUrl('')
+      setDescription('')
+      setWeight('')
+      setCategory('')
+      setActive(true)
+    } else {
+      setCategory(categoryId ?? '')
     }
-  }, [open])
+  }, [open, categoryId])
 
   if (!open) return null
 
   const handleSave = () => {
     const t = title.trim()
     const p = parseFloat(price)
-    if (!t || isNaN(p)) return
-    onSave({ title: t, price: p, category_id: categoryId })
+    if (!t || isNaN(p) || !category) return
+    onSave({
+      title: t,
+      price: p,
+      image_url: imageUrl.trim() || undefined,
+      description: description.trim() || undefined,
+      weight: weight.trim() || undefined,
+      category_id: category,
+      active,
+    })
   }
 
   return createPortal(
@@ -41,7 +81,7 @@ export default function AddProductModal({ open, onClose, onSave, categoryId }) {
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="Введите название"
-          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
         />
 
         <label className="mb-1 block text-sm">Цена</label>
@@ -49,8 +89,57 @@ export default function AddProductModal({ open, onClose, onSave, categoryId }) {
           type="number"
           value={price}
           onChange={(e) => setPrice(e.target.value)}
-          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
         />
+
+        <label className="mb-1 block text-sm">Основное фото (URL)</label>
+        <input
+          type="text"
+          value={imageUrl}
+          onChange={(e) => setImageUrl(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="mb-1 block text-sm">Краткое описание</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="mb-1 block text-sm">Вес/объём</label>
+        <input
+          type="text"
+          value={weight}
+          onChange={(e) => setWeight(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="mb-1 block text-sm">Категория</label>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="" disabled>
+            Выберите категорию
+          </option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.path}
+            </option>
+          ))}
+        </select>
+
+        <label className="mb-1 flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={active}
+            onChange={(e) => setActive(e.target.checked)}
+            className="focus:ring-blue-500"
+          />
+          Активен
+        </label>
 
         <div className="flex justify-end gap-2">
           <button
@@ -60,7 +149,7 @@ export default function AddProductModal({ open, onClose, onSave, categoryId }) {
             Отмена
           </button>
           <button
-            disabled={!title.trim() || !price}
+            disabled={!title.trim() || !price || !category}
             onClick={handleSave}
             className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
           >

--- a/src/pages/Sites/SiteSettings/Products/components/EditProductModal.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/EditProductModal.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function EditProductModal({ open, onClose, onSave, product }) {
+  const [title, setTitle] = useState('')
+  const [price, setPrice] = useState('')
+
+  useEffect(() => {
+    if (open && product) {
+      setTitle(product.title || '')
+      setPrice(String(product.price ?? ''))
+    }
+  }, [open, product])
+
+  if (!open || !product) return null
+
+  const handleSave = () => {
+    const t = title.trim()
+    const p = parseFloat(price)
+    if (!t || isNaN(p)) return
+    onSave({ id: product.id, title: t, price: p })
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Редактировать товар</h3>
+
+        <label className="mb-1 block text-sm">Название</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="mb-1 block text-sm">Цена</label>
+        <input
+          type="number"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!title.trim() || !price}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Сохранить
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/EditProductModal.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/EditProductModal.jsx
@@ -1,5 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { createPortal } from 'react-dom'
+import { useParams } from 'react-router-dom'
+
+import { useCategories } from '../hooks/useCategories'
 
 const modalRoot =
   document.getElementById('modal-root') ||
@@ -11,13 +14,40 @@ const modalRoot =
   })()
 
 export default function EditProductModal({ open, onClose, onSave, product }) {
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
+
+  const { data: tree = [] } = useCategories(siteName)
+
+  const categories = useMemo(() => {
+    const list = []
+    const walk = (nodes, prefix = '') =>
+      nodes.forEach((n) => {
+        const path = prefix ? `${prefix} / ${n.name}` : n.name
+        list.push({ id: n.id, path })
+        if (n.children?.length) walk(n.children, path)
+      })
+    walk(tree)
+    return list
+  }, [tree])
+
   const [title, setTitle] = useState('')
   const [price, setPrice] = useState('')
+  const [imageUrl, setImageUrl] = useState('')
+  const [description, setDescription] = useState('')
+  const [weight, setWeight] = useState('')
+  const [category, setCategory] = useState('')
+  const [active, setActive] = useState(true)
 
   useEffect(() => {
     if (open && product) {
       setTitle(product.title || '')
       setPrice(String(product.price ?? ''))
+      setImageUrl(product.image_url || '')
+      setDescription(product.description || '')
+      setWeight(product.weight || '')
+      setCategory(product.category_id ?? '')
+      setActive(Boolean(product.active))
     }
   }, [open, product])
 
@@ -26,8 +56,17 @@ export default function EditProductModal({ open, onClose, onSave, product }) {
   const handleSave = () => {
     const t = title.trim()
     const p = parseFloat(price)
-    if (!t || isNaN(p)) return
-    onSave({ id: product.id, title: t, price: p })
+    if (!t || isNaN(p) || !category) return
+    onSave({
+      id: product.id,
+      title: t,
+      price: p,
+      image_url: imageUrl.trim() || undefined,
+      description: description.trim() || undefined,
+      weight: weight.trim() || undefined,
+      category_id: category,
+      active,
+    })
   }
 
   return createPortal(
@@ -40,7 +79,7 @@ export default function EditProductModal({ open, onClose, onSave, product }) {
           type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
         />
 
         <label className="mb-1 block text-sm">Цена</label>
@@ -48,8 +87,57 @@ export default function EditProductModal({ open, onClose, onSave, product }) {
           type="number"
           value={price}
           onChange={(e) => setPrice(e.target.value)}
-          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
         />
+
+        <label className="mb-1 block text-sm">Основное фото (URL)</label>
+        <input
+          type="text"
+          value={imageUrl}
+          onChange={(e) => setImageUrl(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="mb-1 block text-sm">Краткое описание</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="mb-1 block text-sm">Вес/объём</label>
+        <input
+          type="text"
+          value={weight}
+          onChange={(e) => setWeight(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="mb-1 block text-sm">Категория</label>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="" disabled>
+            Выберите категорию
+          </option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.path}
+            </option>
+          ))}
+        </select>
+
+        <label className="mb-1 flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={active}
+            onChange={(e) => setActive(e.target.checked)}
+            className="focus:ring-blue-500"
+          />
+          Активен
+        </label>
 
         <div className="flex justify-end gap-2">
           <button
@@ -59,7 +147,7 @@ export default function EditProductModal({ open, onClose, onSave, product }) {
             Отмена
           </button>
           <button
-            disabled={!title.trim() || !price}
+            disabled={!title.trim() || !price || !category}
             onClick={handleSave}
             className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
           >

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/BulkActionsBar.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/BulkActionsBar.jsx
@@ -1,0 +1,13 @@
+export default function BulkActionsBar({ count, onDelete }) {
+  return (
+    <div className="flex items-center justify-between rounded border bg-gray-50 px-2 py-1">
+      <span className="text-sm">Выбрано: {count}</span>
+      <button
+        onClick={onDelete}
+        className="rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500"
+      >
+        Удалить выбранное
+      </button>
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/Pagination.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/Pagination.jsx
@@ -1,0 +1,32 @@
+export default function Pagination({ page, totalPages, setPage }) {
+  if (totalPages <= 1) return null
+  return (
+    <div className="flex justify-center gap-2 text-sm">
+      <button
+        onClick={() => setPage(p => Math.max(1, p - 1))}
+        disabled={page === 1}
+        className="rounded px-2 py-1 hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+      >
+        &lt;
+      </button>
+      {Array.from({ length: totalPages }).map((_, i) => (
+        <button
+          key={i}
+          onClick={() => setPage(i + 1)}
+          className={`rounded px-2 py-1 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 ${
+            page === i + 1 ? 'bg-blue-600 text-white' : ''
+          }`}
+        >
+          {i + 1}
+        </button>
+      ))}
+      <button
+        onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+        disabled={page === totalPages}
+        className="rounded px-2 py-1 hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+      >
+        &gt;
+      </button>
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductRow.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductRow.jsx
@@ -1,0 +1,76 @@
+import { useState, useRef, useEffect } from 'react'
+import { MoreVertical, Edit2, Trash2 } from 'lucide-react'
+
+export default function ProductRow({
+  product,
+  checked,
+  onCheck,
+  onEdit,
+  onDelete,
+}) {
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef(null)
+
+  useEffect(() => {
+    const onClick = (e) => {
+      if (!menuRef.current?.contains(e.target)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  }, [])
+
+  return (
+    <tr className="hover:bg-gray-50 focus-within:bg-gray-50">
+      <td className="px-2 py-1">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={() => onCheck(product.id)}
+          className="focus:ring-blue-500"
+        />
+      </td>
+      <td className="px-2 py-1">
+        {product.image_url ? (
+          <img src={product.image_url} alt="" className="h-10 w-10 object-cover rounded" />
+        ) : (
+          <div className="h-10 w-10 rounded bg-gray-200" />
+        )}
+      </td>
+      <td className="px-2 py-1 text-sm">{product.title}</td>
+      <td className="px-2 py-1 text-sm whitespace-nowrap">{product.price}₽</td>
+      <td className="relative px-2 py-1 text-right">
+        <button
+          className="rounded p-1 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+          onClick={() => setOpen((v) => !v)}
+        >
+          <MoreVertical size={16} />
+        </button>
+        {open && (
+          <div
+            ref={menuRef}
+            className="absolute right-0 z-10 mt-1 w-28 rounded border bg-white py-1 shadow-md"
+          >
+            <button
+              onClick={() => {
+                setOpen(false)
+                onEdit(product)
+              }}
+              className="flex w-full items-center gap-1 px-2 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+            >
+              <Edit2 size={14} /> Редактировать
+            </button>
+            <button
+              onClick={() => {
+                setOpen(false)
+                onDelete(product.id)
+              }}
+              className="flex w-full items-center gap-1 px-2 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+            >
+              <Trash2 size={14} /> Удалить
+            </button>
+          </div>
+        )}
+      </td>
+    </tr>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductRow.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductRow.jsx
@@ -1,5 +1,16 @@
 import { useState, useRef, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
 import { MoreVertical, Edit2, Trash2 } from 'lucide-react'
+
+// преобразуем внутренний/относительный путь в публичный URL
+const toPublicUrl = (raw = '', siteName) => {
+  if (!raw) return null
+  if (/^https?:\/\//i.test(raw) && !raw.includes(`${siteName}:8001`)) return raw
+
+  const base = import.meta.env.VITE_CLOUD_CDN || import.meta.env.VITE_ASSETS_URL || ''
+  if (!base) return raw.startsWith('/') ? raw : `/${raw}`
+  return `${base.replace(/\/$/, '')}/${raw.replace(/^\//, '')}`
+}
 
 export default function ProductRow({
   product,
@@ -8,6 +19,9 @@ export default function ProductRow({
   onEdit,
   onDelete,
 }) {
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
+
   const [open, setOpen] = useState(false)
   const menuRef = useRef(null)
 
@@ -18,6 +32,8 @@ export default function ProductRow({
     document.addEventListener('mousedown', onClick)
     return () => document.removeEventListener('mousedown', onClick)
   }, [])
+
+  const imgSrc = toPublicUrl(product.image_url, siteName)
 
   return (
     <tr className="hover:bg-gray-50 focus-within:bg-gray-50">
@@ -30,13 +46,13 @@ export default function ProductRow({
         />
       </td>
       <td className="px-2 py-1">
-        {product.image_url ? (
-          <img src={product.image_url} alt="" className="h-10 w-10 object-cover rounded" />
+        {imgSrc ? (
+          <img src={imgSrc} alt="" className="h-10 w-10 object-cover rounded" />
         ) : (
-          <div className="h-10 w-10 rounded bg-gray-200" />
+          <div className="h-10 w-10 rounded bg-gray-200 flex items-center justify-center text-xs text-gray-500">—</div>
         )}
       </td>
-      <td className="px-2 py-1 text-sm">{product.title}</td>
+      <td className="px-2 py-1 text-sm max-w-[240px] truncate">{product.title}</td>
       <td className="px-2 py-1 text-sm whitespace-nowrap">{product.price}₽</td>
       <td className="relative px-2 py-1 text-right">
         <button
@@ -64,7 +80,7 @@ export default function ProductRow({
                 setOpen(false)
                 onDelete(product.id)
               }}
-              className="flex w-full items-center gap-1 px-2 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+              className="flex w-full items-center gap-1 px-2 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-red-500"
             >
               <Trash2 size={14} /> Удалить
             </button>

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductTable.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductTable.jsx
@@ -1,0 +1,86 @@
+import ProductRow from './ProductRow'
+
+export default function ProductTable({
+  isFetching,
+  filtered,
+  pageItems,
+  selected,
+  toggleSelect,
+  toggleSelectAll,
+  onEdit,
+  onDelete,
+  onAdd,
+}) {
+  const renderBody = () => {
+    if (isFetching) {
+      return (
+        <tbody>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <tr key={i} className="animate-pulse border-t">
+              <td className="px-2 py-3" colSpan={5}>
+                <div className="h-4 w-full rounded bg-gray-200" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      )
+    }
+
+    if (!filtered.length) {
+      return (
+        <tbody>
+          <tr>
+            <td colSpan={5} className="py-6 text-center text-sm text-gray-500">
+              Вы ещё не добавили ни одного товара
+              <div className="mt-2">
+                <button
+                  onClick={onAdd}
+                  className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+                >
+                  Добавить первый товар
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      )
+    }
+
+    return (
+      <tbody>
+        {pageItems.map((p) => (
+          <ProductRow
+            key={p.id}
+            product={p}
+            checked={selected.has(p.id)}
+            onCheck={toggleSelect}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        ))}
+      </tbody>
+    )
+  }
+
+  return (
+    <table className="w-full border text-left text-sm">
+      <thead className="bg-gray-100">
+        <tr>
+          <th className="w-8 px-2 py-1">
+            <input
+              type="checkbox"
+              onChange={toggleSelectAll}
+              checked={pageItems.length > 0 && pageItems.every((p) => selected.has(p.id))}
+              className="focus:ring-blue-500"
+            />
+          </th>
+          <th className="w-12 px-2 py-1">Фото</th>
+          <th className="px-2 py-1">Название</th>
+          <th className="px-2 py-1">Цена</th>
+          <th className="px-2 py-1" />
+        </tr>
+      </thead>
+      {renderBody()}
+    </table>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
@@ -1,13 +1,16 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { Plus, Filter } from 'lucide-react'
 
 import { useProducts } from '../../hooks/useProducts'
 import { useProductCrud } from '../../hooks/useProductCrud'
 
 import AddProductModal from '../AddProductModal'
 import EditProductModal from '../EditProductModal'
-import ProductRow from './ProductRow'
+import Toolbar from './Toolbar'
+import BulkActionsBar from './BulkActionsBar'
+import ProductTable from './ProductTable'
+import Pagination from './Pagination'
+import useProductsList from './useProductsList'
 
 export default function ProductsList({ category }) {
   const { domain } = useParams()
@@ -16,55 +19,10 @@ export default function ProductsList({ category }) {
   const { data: all = [], isFetching, isError, refetch } = useProducts(siteName)
   const { add, update, remove } = useProductCrud(siteName)
 
-  const [search, setSearch] = useState('')
-  const [debounced, setDebounced] = useState('')
-  const [selected, setSelected] = useState(new Set())
-  const [page, setPage] = useState(1)
+  const list = useProductsList({ products: all, category, removeFn: id => remove.mutateAsync(id) })
+
   const [showAdd, setShowAdd] = useState(false)
   const [edit, setEdit] = useState({ open: false, product: null })
-
-  useEffect(() => {
-    const t = setTimeout(() => setDebounced(search.trim().toLowerCase()), 300)
-    return () => clearTimeout(t)
-  }, [search])
-
-  const filtered = useMemo(() => {
-    let list = category ? all.filter(p => p.category_id === category) : all
-    if (debounced)
-      list = list.filter(p => p.title.toLowerCase().includes(debounced))
-    return list
-  }, [all, category, debounced])
-
-  const pageSize = 10
-  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize))
-  const pageItems = filtered.slice((page - 1) * pageSize, page * pageSize)
-
-  const toggleSelect = (id) => {
-    setSelected(prev => {
-      const next = new Set(prev)
-      next.has(id) ? next.delete(id) : next.add(id)
-      return next
-    })
-  }
-
-  const toggleSelectAll = () => {
-    const ids = pageItems.map(p => p.id)
-    setSelected(prev => {
-      const next = new Set(prev)
-      const allSelected = ids.every(id => next.has(id))
-      if (allSelected) ids.forEach(id => next.delete(id))
-      else ids.forEach(id => next.add(id))
-      return next
-    })
-  }
-
-  const handleDeleteSelected = async () => {
-    for (const id of selected) {
-      // eslint-disable-next-line no-await-in-loop
-      await remove.mutateAsync(id)
-    }
-    setSelected(new Set())
-  }
 
   if (isError) {
     return (
@@ -80,144 +38,28 @@ export default function ProductsList({ category }) {
     )
   }
 
-  const renderTable = () => {
-    if (isFetching) {
-      return (
-        <tbody>
-          {Array.from({ length: 5 }).map((_, i) => (
-            <tr key={i} className="animate-pulse border-t">
-              <td className="px-2 py-3" colSpan={5}>
-                <div className="h-4 w-full rounded bg-gray-200" />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      )
-    }
-
-    if (!filtered.length) {
-      return (
-        <tbody>
-          <tr>
-            <td colSpan={5} className="py-6 text-center text-sm text-gray-500">
-              Вы ещё не добавили ни одного товара
-              <div className="mt-2">
-                <button
-                  onClick={() => setShowAdd(true)}
-                  className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
-                >
-                  Добавить первый товар
-                </button>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      )
-    }
-
-    return (
-      <tbody>
-        {pageItems.map(p => (
-          <ProductRow
-            key={p.id}
-            product={p}
-            checked={selected.has(p.id)}
-            onCheck={toggleSelect}
-            onEdit={prod => setEdit({ open: true, product: prod })}
-            onDelete={id => remove.mutateAsync(id)}
-          />
-        ))}
-      </tbody>
-    )
-  }
-
   return (
     <div className="space-y-4">
-      {/* header */}
-      {selected.size ? (
-        <div className="flex items-center justify-between rounded border bg-gray-50 px-2 py-1">
-          <span className="text-sm">Выбрано: {selected.size}</span>
-          <button
-            onClick={handleDeleteSelected}
-            className="rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500"
-          >
-            Удалить выбранное
-          </button>
-        </div>
+      {list.selected.size ? (
+        <BulkActionsBar count={list.selected.size} onDelete={list.deleteSelected} />
       ) : (
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            onClick={() => setShowAdd(true)}
-            className="flex items-center gap-1 rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
-          >
-            <Plus size={16} /> Добавить товар
-          </button>
-          <button
-            className="rounded border px-3 py-1 text-sm text-gray-600 focus:ring-2 focus:ring-blue-500"
-          >
-            Фильтры
-          </button>
-          <input
-            type="text"
-            placeholder="Поиск..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="ml-auto w-48 rounded border px-2 py-1 text-sm focus:ring-2 focus:ring-blue-500"
-          />
-        </div>
+        <Toolbar onAdd={() => setShowAdd(true)} search={list.search} onSearch={list.setSearch} />
       )}
 
-      {/* table */}
-      <table className="w-full border text-left text-sm">
-        <thead className="bg-gray-100">
-          <tr>
-            <th className="w-8 px-2 py-1">
-              <input
-                type="checkbox"
-                onChange={toggleSelectAll}
-                checked={pageItems.length > 0 && pageItems.every(p => selected.has(p.id))}
-                className="focus:ring-blue-500"
-              />
-            </th>
-            <th className="w-12 px-2 py-1">Фото</th>
-            <th className="px-2 py-1">Название</th>
-            <th className="px-2 py-1">Цена</th>
-            <th className="px-2 py-1" />
-          </tr>
-        </thead>
-        {renderTable()}
-      </table>
+      <ProductTable
+        isFetching={isFetching}
+        filtered={list.filtered}
+        pageItems={list.pageItems}
+        selected={list.selected}
+        toggleSelect={list.toggleSelect}
+        toggleSelectAll={list.toggleSelectAll}
+        onEdit={prod => setEdit({ open: true, product: prod })}
+        onDelete={id => remove.mutateAsync(id)}
+        onAdd={() => setShowAdd(true)}
+      />
 
-      {/* pagination */}
-      {filtered.length > pageSize && (
-        <div className="flex justify-center gap-2 text-sm">
-          <button
-            onClick={() => setPage(p => Math.max(1, p - 1))}
-            disabled={page === 1}
-            className="rounded px-2 py-1 hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
-          >
-            &lt;
-          </button>
-          {Array.from({ length: totalPages }).map((_, i) => (
-            <button
-              key={i}
-              onClick={() => setPage(i + 1)}
-              className={`rounded px-2 py-1 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 ${page === i + 1 ? 'bg-blue-600 text-white' : ''}`}
-            >
-              {i + 1}
-            </button>
-          ))}
-          <button
-            onClick={() => setPage(p => Math.min(totalPages, p + 1))}
-            disabled={page === totalPages}
-            className="rounded px-2 py-1 hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
-          >
-            &gt;
-          </button>
-        </div>
-      )}
+      <Pagination page={list.page} totalPages={list.totalPages} setPage={list.setPage} />
 
-      {/* modals */}
       <AddProductModal
         open={showAdd}
         onClose={() => setShowAdd(false)}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 
 import { useProducts } from '../../hooks/useProducts'
 import { useProductCrud } from '../../hooks/useProductCrud'
+import { useCategories } from '../../hooks/useCategories' // ✅ добавлен импорт
 
 import AddProductModal from '../AddProductModal'
 import EditProductModal from '../EditProductModal'
@@ -18,8 +19,14 @@ export default function ProductsList({ category }) {
 
   const { data: all = [], isFetching, isError, refetch } = useProducts(siteName)
   const { add, update, remove } = useProductCrud(siteName)
+  const { tree = [] } = useCategories(siteName) // ✅ получили дерево категорий
 
-  const list = useProductsList({ products: all, category, removeFn: id => remove.mutateAsync(id) })
+  const list = useProductsList({
+    products: all,
+    category,
+    categories: tree, // ✅ передаём дерево
+    removeFn: remove.mutateAsync,
+  })
 
   const [showAdd, setShowAdd] = useState(false)
   const [edit, setEdit] = useState({ open: false, product: null })

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
@@ -1,38 +1,241 @@
-// FILE: src/pages/Sites/SiteSettings/Products/components/ProductsList.jsx
-const mockProducts = [
-  { id: 1, categoryId: 1, title: 'Маргарита', price: 250 },
-  { id: 2, categoryId: 1, title: 'Пепперони', price: 290 },
-  { id: 3, categoryId: 2, title: 'Кола 0.5', price: 60 },
-  { id: 4, categoryId: 3, title: 'Чизкейк', price: 120 },
-]
+import { useEffect, useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Plus, Filter } from 'lucide-react'
+
+import { useProducts } from '../../hooks/useProducts'
+import { useProductCrud } from '../../hooks/useProductCrud'
+
+import AddProductModal from '../AddProductModal'
+import EditProductModal from '../EditProductModal'
+import ProductRow from './ProductRow'
 
 export default function ProductsList({ category }) {
-  const products = category
-    ? mockProducts.filter(p => p.categoryId === category)
-    : mockProducts
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
 
-  if (!products.length) {
-    return <p className="text-gray-500">Нет товаров в этой категории.</p>
+  const { data: all = [], isFetching, isError, refetch } = useProducts(siteName)
+  const { add, update, remove } = useProductCrud(siteName)
+
+  const [search, setSearch] = useState('')
+  const [debounced, setDebounced] = useState('')
+  const [selected, setSelected] = useState(new Set())
+  const [page, setPage] = useState(1)
+  const [showAdd, setShowAdd] = useState(false)
+  const [edit, setEdit] = useState({ open: false, product: null })
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(search.trim().toLowerCase()), 300)
+    return () => clearTimeout(t)
+  }, [search])
+
+  const filtered = useMemo(() => {
+    let list = category ? all.filter(p => p.category_id === category) : all
+    if (debounced)
+      list = list.filter(p => p.title.toLowerCase().includes(debounced))
+    return list
+  }, [all, category, debounced])
+
+  const pageSize = 10
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize))
+  const pageItems = filtered.slice((page - 1) * pageSize, page * pageSize)
+
+  const toggleSelect = (id) => {
+    setSelected(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
+
+  const toggleSelectAll = () => {
+    const ids = pageItems.map(p => p.id)
+    setSelected(prev => {
+      const next = new Set(prev)
+      const allSelected = ids.every(id => next.has(id))
+      if (allSelected) ids.forEach(id => next.delete(id))
+      else ids.forEach(id => next.add(id))
+      return next
+    })
+  }
+
+  const handleDeleteSelected = async () => {
+    for (const id of selected) {
+      // eslint-disable-next-line no-await-in-loop
+      await remove.mutateAsync(id)
+    }
+    setSelected(new Set())
+  }
+
+  if (isError) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-red-600">Не удалось загрузить товары</p>
+        <button
+          onClick={() => refetch()}
+          className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+        >
+          Попробовать снова
+        </button>
+      </div>
+    )
+  }
+
+  const renderTable = () => {
+    if (isFetching) {
+      return (
+        <tbody>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <tr key={i} className="animate-pulse border-t">
+              <td className="px-2 py-3" colSpan={5}>
+                <div className="h-4 w-full rounded bg-gray-200" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      )
+    }
+
+    if (!filtered.length) {
+      return (
+        <tbody>
+          <tr>
+            <td colSpan={5} className="py-6 text-center text-sm text-gray-500">
+              Вы ещё не добавили ни одного товара
+              <div className="mt-2">
+                <button
+                  onClick={() => setShowAdd(true)}
+                  className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+                >
+                  Добавить первый товар
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      )
+    }
+
+    return (
+      <tbody>
+        {pageItems.map(p => (
+          <ProductRow
+            key={p.id}
+            product={p}
+            checked={selected.has(p.id)}
+            onCheck={toggleSelect}
+            onEdit={prod => setEdit({ open: true, product: prod })}
+            onDelete={id => remove.mutateAsync(id)}
+          />
+        ))}
+      </tbody>
+    )
   }
 
   return (
-    <table className="min-w-full border rounded">
-      <thead>
-        <tr className="bg-gray-100 text-left">
-          <th className="px-4 py-2">ID</th>
-          <th className="px-4 py-2">Название</th>
-          <th className="px-4 py-2">Цена</th>
-        </tr>
-      </thead>
-      <tbody>
-        {products.map(prod => (
-          <tr key={prod.id} className="border-t">
-            <td className="px-4 py-2">{prod.id}</td>
-            <td className="px-4 py-2">{prod.title}</td>
-            <td className="px-4 py-2">{prod.price}₽</td>
+    <div className="space-y-4">
+      {/* header */}
+      {selected.size ? (
+        <div className="flex items-center justify-between rounded border bg-gray-50 px-2 py-1">
+          <span className="text-sm">Выбрано: {selected.size}</span>
+          <button
+            onClick={handleDeleteSelected}
+            className="rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500"
+          >
+            Удалить выбранное
+          </button>
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            onClick={() => setShowAdd(true)}
+            className="flex items-center gap-1 rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+          >
+            <Plus size={16} /> Добавить товар
+          </button>
+          <button
+            className="rounded border px-3 py-1 text-sm text-gray-600 focus:ring-2 focus:ring-blue-500"
+          >
+            Фильтры
+          </button>
+          <input
+            type="text"
+            placeholder="Поиск..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="ml-auto w-48 rounded border px-2 py-1 text-sm focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      )}
+
+      {/* table */}
+      <table className="w-full border text-left text-sm">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="w-8 px-2 py-1">
+              <input
+                type="checkbox"
+                onChange={toggleSelectAll}
+                checked={pageItems.length > 0 && pageItems.every(p => selected.has(p.id))}
+                className="focus:ring-blue-500"
+              />
+            </th>
+            <th className="w-12 px-2 py-1">Фото</th>
+            <th className="px-2 py-1">Название</th>
+            <th className="px-2 py-1">Цена</th>
+            <th className="px-2 py-1" />
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        {renderTable()}
+      </table>
+
+      {/* pagination */}
+      {filtered.length > pageSize && (
+        <div className="flex justify-center gap-2 text-sm">
+          <button
+            onClick={() => setPage(p => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="rounded px-2 py-1 hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            &lt;
+          </button>
+          {Array.from({ length: totalPages }).map((_, i) => (
+            <button
+              key={i}
+              onClick={() => setPage(i + 1)}
+              className={`rounded px-2 py-1 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 ${page === i + 1 ? 'bg-blue-600 text-white' : ''}`}
+            >
+              {i + 1}
+            </button>
+          ))}
+          <button
+            onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages}
+            className="rounded px-2 py-1 hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            &gt;
+          </button>
+        </div>
+      )}
+
+      {/* modals */}
+      <AddProductModal
+        open={showAdd}
+        onClose={() => setShowAdd(false)}
+        onSave={async payload => {
+          await add.mutateAsync(payload)
+          setShowAdd(false)
+        }}
+        categoryId={category}
+      />
+      <EditProductModal
+        open={edit.open}
+        product={edit.product}
+        onClose={() => setEdit({ open: false, product: null })}
+        onSave={async payload => {
+          await update.mutateAsync(payload)
+          setEdit({ open: false, product: null })
+        }}
+      />
+    </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
@@ -19,7 +19,7 @@ export default function ProductsList({ category }) {
 
   const { data: all = [], isFetching, isError, refetch } = useProducts(siteName)
   const { add, update, remove } = useProductCrud(siteName)
-  const { tree = [] } = useCategories(siteName) // ✅ получили дерево категорий
+  const { data: tree = [] } = useCategories(siteName) // ✅ получили дерево категорий
 
   const list = useProductsList({
     products: all,

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/Toolbar.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/Toolbar.jsx
@@ -1,0 +1,24 @@
+import { Plus } from 'lucide-react'
+
+export default function Toolbar({ onAdd, search, onSearch }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        onClick={onAdd}
+        className="flex items-center gap-1 rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+      >
+        <Plus size={16} /> Добавить товар
+      </button>
+      <button className="rounded border px-3 py-1 text-sm text-gray-600 focus:ring-2 focus:ring-blue-500">
+        Фильтры
+      </button>
+      <input
+        type="text"
+        placeholder="Поиск..."
+        value={search}
+        onChange={(e) => onSearch(e.target.value)}
+        className="ml-auto w-48 rounded border px-2 py-1 text-sm focus:ring-2 focus:ring-blue-500"
+      />
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/useProductsList.js
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/useProductsList.js
@@ -1,0 +1,69 @@
+import { useEffect, useMemo, useState } from 'react'
+
+export default function useProductsList({ products = [], category, removeFn }) {
+  const [search, setSearch] = useState('')
+  const [debounced, setDebounced] = useState('')
+  const [selected, setSelected] = useState(new Set())
+  const [page, setPage] = useState(1)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(search.trim().toLowerCase()), 300)
+    return () => clearTimeout(t)
+  }, [search])
+
+  const filtered = useMemo(() => {
+    let list = category ? products.filter(p => p.category_id === category) : products
+    if (debounced) list = list.filter(p => p.title.toLowerCase().includes(debounced))
+    return list
+  }, [products, category, debounced])
+
+  const pageSize = 10
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize))
+  const pageItems = filtered.slice((page - 1) * pageSize, page * pageSize)
+
+  const toggleSelect = (id) => {
+    setSelected(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
+
+  const toggleSelectAll = () => {
+    const ids = pageItems.map(p => p.id)
+    setSelected(prev => {
+      const next = new Set(prev)
+      const allSelected = ids.every(id => next.has(id))
+      if (allSelected) ids.forEach(id => next.delete(id))
+      else ids.forEach(id => next.add(id))
+      return next
+    })
+  }
+
+  const deleteSelected = async () => {
+    for (const id of selected) {
+      // eslint-disable-next-line no-await-in-loop
+      await removeFn(id)
+    }
+    setSelected(new Set())
+  }
+
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages)
+  }, [page, totalPages])
+
+  return {
+    search,
+    setSearch,
+    selected,
+    toggleSelect,
+    toggleSelectAll,
+    deleteSelected,
+    page,
+    setPage,
+    pageItems,
+    filtered,
+    totalPages,
+    pageSize,
+  }
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/useProductsList.js
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/useProductsList.js
@@ -1,5 +1,17 @@
 import { useEffect, useMemo, useState } from 'react'
 
+function flattenTree(tree = []) {
+  const list = []
+  const walk = (nodes) => {
+    nodes.forEach((n) => {
+      list.push(n)
+      if (n.children?.length) walk(n.children)
+    })
+  }
+  walk(tree)
+  return list
+}
+
 function getAllNestedCategoryIds(rootId, categories = []) {
   const ids = new Set()
   const walk = (id) => {
@@ -18,6 +30,8 @@ export default function useProductsList({ products = [], category, categories = 
   const [selected, setSelected] = useState(new Set())
   const [page, setPage] = useState(1)
 
+  const flatCategories = useMemo(() => flattenTree(categories), [categories])
+
   // ─── Debounce поиска ─────────────────────────────────────────
   useEffect(() => {
     const t = setTimeout(() => setDebounced(search.trim().toLowerCase()), 300)
@@ -28,8 +42,8 @@ export default function useProductsList({ products = [], category, categories = 
   const filtered = useMemo(() => {
     let list = products
 
-    if (category && categories.length) {
-      const allowedIds = getAllNestedCategoryIds(category, categories)
+    if (category && flatCategories.length) {
+      const allowedIds = getAllNestedCategoryIds(category, flatCategories)
       list = list.filter((p) => allowedIds.has(Number(p.category_id)))
     }
 
@@ -38,7 +52,7 @@ export default function useProductsList({ products = [], category, categories = 
     }
 
     return list
-  }, [products, category, debounced, categories])
+  }, [products, category, debounced, flatCategories])
 
   // ─── Пагинация ───────────────────────────────────────────────
   const pageSize = 10

--- a/src/pages/Sites/SiteSettings/Products/hooks/useProductCrud.js
+++ b/src/pages/Sites/SiteSettings/Products/hooks/useProductCrud.js
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useProductCrud(siteName) {
+  const qc = useQueryClient()
+
+  const add = useMutation({
+    mutationFn: async (payload) => {
+      const res = await fetch(`${API_URL}/products/${siteName}/add`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!res.ok) throw new Error('Ошибка создания товара')
+      return res.json()
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['products', siteName] }),
+  })
+
+  const update = useMutation({
+    mutationFn: async ({ id, ...rest }) => {
+      const res = await fetch(`${API_URL}/products/${siteName}/update/${id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(rest),
+      })
+      if (!res.ok) throw new Error('Ошибка обновления товара')
+      return res.json()
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['products', siteName] }),
+  })
+
+  const remove = useMutation({
+    mutationFn: async (id) => {
+      const res = await fetch(`${API_URL}/products/${siteName}/delete/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Ошибка удаления товара')
+      return res.json()
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['products', siteName] }),
+  })
+
+  return { add, update, remove }
+}

--- a/src/pages/Sites/SiteSettings/Products/hooks/useProducts.js
+++ b/src/pages/Sites/SiteSettings/Products/hooks/useProducts.js
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useProducts(siteName, options = {}) {
+  return useQuery({
+    queryKey: ['products', siteName],
+    queryFn: async () => {
+      const res = await fetch(
+        `${API_URL}/products/${siteName}/all`,
+        { credentials: 'include' },
+      )
+      if (!res.ok) throw new Error('Не удалось получить товары')
+      return res.json()
+    },
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}


### PR DESCRIPTION
## Summary
- add hooks for products API requests
- implement modal windows to create and edit products
- render table of products with bulk actions, search and pagination
- add row actions via context menu

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68515a71f624833186eb6df04b6bbe23