### PR TITLE
Extend product table with more columns

### DIFF
--- a/src/pages/Sites/SiteSettings/Products/components/AddCategoryModal.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/AddCategoryModal.jsx
@@ -1,4 +1,3 @@
-// FILE: src/pages/Sites/SiteSettings/Products/components/AddCategoryModal.jsx
 import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 
@@ -14,20 +13,27 @@ const modalRoot =
 export default function AddCategoryModal({ open, onClose, onSave, parents }) {
   const [name, setName] = useState('')
   const [parent, setParent] = useState(null)
+  const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     if (!open) {
       setName('')
       setParent(null)
+      setLoading(false)
     }
   }, [open])
 
   if (!open) return null
 
-  const handleSave = () => {
+  const handleSave = async () => {
     const val = name.trim()
     if (!val) return
-    onSave({ name: val, parent_id: parent })
+    setLoading(true)
+    try {
+      await onSave({ name: val, parent_id: parent })
+    } finally {
+      setLoading(false)
+    }
   }
 
   return createPortal(
@@ -42,6 +48,7 @@ export default function AddCategoryModal({ open, onClose, onSave, parents }) {
           onChange={(e) => setName(e.target.value)}
           placeholder="Введите название"
           className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
         />
 
         <label className="mb-1 block text-sm">Родитель</label>
@@ -51,6 +58,7 @@ export default function AddCategoryModal({ open, onClose, onSave, parents }) {
             setParent(e.target.value === '' ? null : Number(e.target.value))
           }
           className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
         >
           <option value="">Без родителя</option>
           {parents.map((p) => (
@@ -63,16 +71,17 @@ export default function AddCategoryModal({ open, onClose, onSave, parents }) {
         <div className="flex justify-end gap-2">
           <button
             onClick={onClose}
-            className="rounded px-3 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+            disabled={loading}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
           >
             Отмена
           </button>
           <button
-            disabled={!name.trim()}
+            disabled={!name.trim() || loading}
             onClick={handleSave}
             className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
           >
-            Сохранить
+            {loading ? 'Сохранение…' : 'Сохранить'}
           </button>
         </div>
       </div>

--- a/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryItem.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryItem.jsx
@@ -1,4 +1,3 @@
-// FILE: src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryItem.jsx
 import { ChevronRight, ChevronDown, Pencil, Trash2 } from 'lucide-react'
 
 export default function CategoryItem({
@@ -14,12 +13,11 @@ export default function CategoryItem({
   FolderIcon,
   TagIcon,
 }) {
-  const hasChildren  = Boolean(cat.children?.length)
-  const isCollapsed  = collapsed.has(cat.id)
-  const isActive     =
+  const hasChildren = Boolean(cat.children?.length)
+  const isCollapsed = collapsed.has(cat.id)
+  const isActive =
     (cat.id === 'all' && selected === null) || selected === cat.id
 
-  // готовим HTML-строку с подсветкой или обычный текст
   const labelHtml = highlight ? highlight(cat.name) : cat.name
 
   return (
@@ -31,12 +29,10 @@ export default function CategoryItem({
         data-kb-expand={hasChildren && !isCollapsed}
         tabIndex={0}
         style={{ paddingLeft: depth * 16 + 8 }}
-        className={`group flex items-center justify-between rounded px-2 py-1 text-sm cursor-pointer focus:ring-2 focus:ring-blue-500
+        className={`group flex items-center justify-between rounded px-2 py-1 text-sm cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-blue-400
           ${isActive
-            ? 'bg-blue-600 text-white'
-            : cat.id === 'all'
-            ? 'hover:bg-gray-100/70'
-            : 'hover:bg-gray-100'}`}
+            ? 'bg-blue-100 text-blue-700 font-medium border-l-2 border-blue-600'
+            : 'hover:bg-gray-100 text-gray-700'}`}
         onClick={() => {
           if (hasChildren) toggle(cat.id)
           onSelect(cat.id === 'all' ? null : cat.id)
@@ -54,7 +50,7 @@ export default function CategoryItem({
 
           {hasChildren
             ? <FolderIcon size={14} className="opacity-70" />
-            : <TagIcon    size={14} className="opacity-70" />}
+            : <TagIcon size={14} className="opacity-70" />}
 
           <span dangerouslySetInnerHTML={{ __html: labelHtml }} />
         </div>
@@ -65,7 +61,7 @@ export default function CategoryItem({
             <span
               className={`min-w-[1.5rem] rounded px-1.5 py-0.5 text-center text-xs
                 ${isActive
-                  ? 'bg-white/20'
+                  ? 'bg-blue-100 text-blue-700'
                   : 'bg-gray-200 dark:bg-gray-700 dark:text-gray-100'}`}
             >
               {cat.count}

--- a/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryList.jsx
@@ -89,7 +89,7 @@ export default function CategoryList({ selected, onSelect, tab, setTab }) {
             ))}
           </nav>
         ) : (
-          <LabelsList siteName={siteName} />
+          <LabelsList siteName={siteName} selected={selected} onSelect={onSelect} />
         )}
       </div>
 

--- a/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryList.jsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef } from 'react'
 import { useParams } from 'react-router-dom'
-import { Plus, Folder, Tag } from 'lucide-react'
+import { Folder, Tag } from 'lucide-react'
 
 import { useCategories } from '../../hooks/useCategories'
 import { useKeyboardTreeNav } from '../../hooks/useKeyboardTreeNav'
@@ -10,6 +10,7 @@ import CategoryItem from './CategoryItem'
 import AddCategoryModal from '../AddCategoryModal'
 import EditCategoryModal from '../EditCategoryModal'
 import LabelsList from '../Labels/LabelsList'
+import CategoryToolbar from './CategoryToolbar'
 
 import { filterTree, highlight } from './TreeUtils'
 
@@ -59,66 +60,39 @@ export default function CategoryList({ selected, onSelect }) {
     })
 
   return (
-    <div ref={containerRef} className="relative h-full space-y-3 overflow-y-auto focus:outline-none" tabIndex={0}>
-      {/* Tabs */}
-      <div className="flex gap-2">
-        <button
-          className={`rounded px-2 py-1 text-sm ${tab === 'categories' ? 'bg-blue-600 text-white' : 'bg-gray-100'}`}
-          onClick={() => setTab('categories')}
-        >Категории</button>
-        <button
-          className={`rounded px-2 py-1 text-sm ${tab === 'labels' ? 'bg-blue-600 text-white' : 'bg-gray-100'}`}
-          onClick={() => setTab('labels')}
-        >Метки</button>
+    <div ref={containerRef} className="relative h-full space-y-4 focus:outline-none" tabIndex={0}>
+      <CategoryToolbar
+        tab={tab}
+        onTabChange={setTab}
+        onAddClick={() => setShowAdd(true)}
+        search={search}
+        setSearch={setSearch}
+      />
+
+      <div className="overflow-y-auto">
+        {tab === 'categories' ? (
+          <nav className="space-y-1 pt-1">
+            {filtered.map(c => (
+              <CategoryItem
+                key={c.id}
+                cat={c}
+                depth={0}
+                collapsed={collapsed}
+                toggle={toggle}
+                highlight={txt => highlight(txt, search)}
+                selected={selected}
+                onSelect={onSelect}
+                onEdit={cat => setEditState({ open: true, category: cat })}
+                onDelete={id => deleteCat.mutateAsync(id)}
+                FolderIcon={Folder}
+                TagIcon={Tag}
+              />
+            ))}
+          </nav>
+        ) : (
+          <LabelsList siteName={siteName} />
+        )}
       </div>
-
-      {/* Header */}
-      {tab === 'categories' && (
-        <div className="flex items-center justify-between">
-          <span className="text-sm font-semibold">Категории товаров</span>
-          <button
-            onClick={() => setShowAdd(true)}
-            className="flex items-center gap-1 rounded bg-blue-600 px-2 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
-          >
-            <Plus size={14} /> Добавить
-          </button>
-        </div>
-      )}
-
-      {/* Search */}
-      {tab === 'categories' && (
-        <input
-          type="text"
-          placeholder="Поиск..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="w-full rounded border px-2 py-1 text-sm focus:ring-2 focus:ring-blue-500"
-        />
-      )}
-
-      {/* Content */}
-      {tab === 'categories' ? (
-        <nav>
-          {filtered.map(c => (
-            <CategoryItem
-              key={c.id}
-              cat={c}
-              depth={0}
-              collapsed={collapsed}
-              toggle={toggle}
-              highlight={txt => highlight(txt, search)}
-              selected={selected}
-              onSelect={onSelect}
-              onEdit={cat => setEditState({ open: true, category: cat })}
-              onDelete={id => deleteCat.mutateAsync(id)}
-              FolderIcon={Folder}
-              TagIcon={Tag}
-            />
-          ))}
-        </nav>
-      ) : (
-        <LabelsList siteName={siteName} />
-      )}
 
       <AddCategoryModal
         open={showAdd}

--- a/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryList.jsx
@@ -1,40 +1,34 @@
-// FILE: src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryList.jsx
 import { useState, useMemo, useRef } from 'react'
 import { useParams } from 'react-router-dom'
-import {
-  Plus,
-  Folder,
-  Tag,
-} from 'lucide-react'
+import { Plus, Folder, Tag } from 'lucide-react'
 
-import { useCategories }    from '../../hooks/useCategories'
+import { useCategories } from '../../hooks/useCategories'
 import { useKeyboardTreeNav } from '../../hooks/useKeyboardTreeNav'
-import { useCategoryCrud }  from './useCategoryCrud'
+import { useCategoryCrud } from './useCategoryCrud'
 
-import CategoryItem     from './CategoryItem'
-import AddCategoryModal  from '../AddCategoryModal'
+import CategoryItem from './CategoryItem'
+import AddCategoryModal from '../AddCategoryModal'
 import EditCategoryModal from '../EditCategoryModal'
+import LabelsList from '../Labels/LabelsList'
 
 import { filterTree, highlight } from './TreeUtils'
 
 export default function CategoryList({ selected, onSelect }) {
-  /* ───── API & CRUD ───── */
-  const { domain }   = useParams()
-  const siteName     = `${domain}_app`
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
 
   const { data: tree = [], isFetching, refetch } = useCategories(siteName)
   const { add: addCat, update: updateCat, remove: deleteCat } = useCategoryCrud(siteName, refetch)
 
-  /* ───── UI state ───── */
-  const [search,      setSearch]      = useState('')
-  const [collapsed,   setCollapsed]   = useState(new Set())
-  const [showAdd,     setShowAdd]     = useState(false)
-  const [editState,   setEditState]   = useState({ open: false, category: null })
+  const [search, setSearch] = useState('')
+  const [collapsed, setCollapsed] = useState(new Set())
+  const [showAdd, setShowAdd] = useState(false)
+  const [editState, setEditState] = useState({ open: false, category: null })
+  const [tab, setTab] = useState('categories')
 
   const containerRef = useRef(null)
-  useKeyboardTreeNav(containerRef, collapsed)          // ♿ стрелки / разворачивание
+  useKeyboardTreeNav(containerRef, collapsed)
 
-  /* ───── derived data ───── */
   const categories = useMemo(() => {
     const total = tree.reduce((s, n) => s + (n.count ?? 0), 0)
     return [{ id: 'all', name: 'Все товары', count: total }, ...tree]
@@ -64,55 +58,68 @@ export default function CategoryList({ selected, onSelect }) {
       return next
     })
 
-  /* ───── render ───── */
   return (
-    <div
-      ref={containerRef}
-      className="relative h-full space-y-3 overflow-y-auto focus:outline-none"
-      tabIndex={0}
-    >
-      {/* header */}
-      <header className="flex items-center justify-between">
-        <h2 className="font-semibold">Категории</h2>
+    <div ref={containerRef} className="relative h-full space-y-3 overflow-y-auto focus:outline-none" tabIndex={0}>
+      {/* Tabs */}
+      <div className="flex gap-2">
         <button
-          className="flex items-center gap-1 rounded bg-blue-600 px-2 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
-          onClick={() => setShowAdd(true)}
-        >
-          <Plus size={16} />
-          Добавить
-        </button>
-      </header>
+          className={`rounded px-2 py-1 text-sm ${tab === 'categories' ? 'bg-blue-600 text-white' : 'bg-gray-100'}`}
+          onClick={() => setTab('categories')}
+        >Категории</button>
+        <button
+          className={`rounded px-2 py-1 text-sm ${tab === 'labels' ? 'bg-blue-600 text-white' : 'bg-gray-100'}`}
+          onClick={() => setTab('labels')}
+        >Метки</button>
+      </div>
 
-      {/* search */}
-      <input
-        type="text"
-        placeholder="Поиск..."
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        className="w-full rounded border px-2 py-1 text-sm focus:ring-2 focus:ring-blue-500"
-      />
+      {/* Header */}
+      {tab === 'categories' && (
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold">Категории товаров</span>
+          <button
+            onClick={() => setShowAdd(true)}
+            className="flex items-center gap-1 rounded bg-blue-600 px-2 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+          >
+            <Plus size={14} /> Добавить
+          </button>
+        </div>
+      )}
 
-      {/* tree */}
-      <nav>
-        {filtered.map(c =>
-          <CategoryItem
-            key={c.id}
-            cat={c}
-            depth={0}
-            collapsed={collapsed}
-            toggle={toggle}
-            highlight={txt => highlight(txt, search)}
-            selected={selected}
-            onSelect={onSelect}
-            onEdit={cat => setEditState({ open: true, category: cat })}
-            onDelete={id => deleteCat.mutateAsync(id)}
-            FolderIcon={Folder}
-            TagIcon={Tag}
-          />
-        )}
-      </nav>
+      {/* Search */}
+      {tab === 'categories' && (
+        <input
+          type="text"
+          placeholder="Поиск..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full rounded border px-2 py-1 text-sm focus:ring-2 focus:ring-blue-500"
+        />
+      )}
 
-      {/* modals */}
+      {/* Content */}
+      {tab === 'categories' ? (
+        <nav>
+          {filtered.map(c => (
+            <CategoryItem
+              key={c.id}
+              cat={c}
+              depth={0}
+              collapsed={collapsed}
+              toggle={toggle}
+              highlight={txt => highlight(txt, search)}
+              selected={selected}
+              onSelect={onSelect}
+              onEdit={cat => setEditState({ open: true, category: cat })}
+              onDelete={id => deleteCat.mutateAsync(id)}
+              FolderIcon={Folder}
+              TagIcon={Tag}
+            />
+          ))}
+        </nav>
+      ) : (
+        <LabelsList siteName={siteName} />
+      )}
+
       <AddCategoryModal
         open={showAdd}
         onClose={() => setShowAdd(false)}

--- a/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryList.jsx
@@ -14,7 +14,7 @@ import CategoryToolbar from './CategoryToolbar'
 
 import { filterTree, highlight } from './TreeUtils'
 
-export default function CategoryList({ selected, onSelect }) {
+export default function CategoryList({ selected, onSelect, tab, setTab }) {
   const { domain } = useParams()
   const siteName = `${domain}_app`
 
@@ -25,7 +25,6 @@ export default function CategoryList({ selected, onSelect }) {
   const [collapsed, setCollapsed] = useState(new Set())
   const [showAdd, setShowAdd] = useState(false)
   const [editState, setEditState] = useState({ open: false, category: null })
-  const [tab, setTab] = useState('categories')
 
   const containerRef = useRef(null)
   useKeyboardTreeNav(containerRef, collapsed)

--- a/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryToolbar.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/CategoryList/CategoryToolbar.jsx
@@ -1,0 +1,96 @@
+import { Plus, Folder, Tag, Search, X } from 'lucide-react'
+import { useState } from 'react';
+
+export default function CategoryToolbar({ tab, onTabChange, onAddClick, search, setSearch }) {
+  const [showSearchInput, setShowSearchInput] = useState(false);
+
+  const commonTabStyles =
+    'flex items-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500'
+  const activeTabStyles = 'bg-blue-100 text-blue-700'
+  const inactiveTabStyles = 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+
+  const handleToggleSearch = () => {
+    setShowSearchInput(prev => !prev);
+    // If hiding, clear the search
+    if (showSearchInput) {
+      setSearch('');
+    }
+  };
+
+  const handleClearSearch = () => {
+    setSearch('');
+  };
+
+  return (
+    <>
+      {/* Tabs */}
+      <div className="flex items-center gap-2 border-b border-gray-200 pb-3">
+        <button
+          className={`${commonTabStyles} ${tab === 'categories' ? activeTabStyles : inactiveTabStyles}`}
+          onClick={() => onTabChange('categories')}
+        >
+          <Folder size={14} className="mr-1.5" />
+          Категории
+        </button>
+        <button
+          className={`${commonTabStyles} ${tab === 'labels' ? activeTabStyles : inactiveTabStyles}`}
+          onClick={() => onTabChange('labels')}
+        >
+          <Tag size={14} className="mr-1.5" />
+          Метки
+        </button>
+      </div>
+
+      {/* Actions (for categories) */}
+      {tab === 'categories' && (
+        <div className="flex flex-col gap-3 mt-4"> {/* Changed to flex-col and added gap */}
+          <div className="flex items-center justify-between"> {/* Row for Add button and Search icon */}
+            <button
+              onClick={onAddClick}
+              className="flex-shrink-0 flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              <Plus size={14} /> Добавить категорию
+            </button>
+
+            {/* Search toggle button */}
+            <button
+              onClick={handleToggleSearch}
+              className="p-1 rounded-full text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              aria-label={showSearchInput ? "Скрыть поиск" : "Показать поиск"}
+            >
+              <Search size={20} />
+            </button>
+          </div>
+
+          {/* Search Input Field (conditionally rendered) */}
+          <div
+            className={`overflow-hidden transition-[max-height,opacity] duration-300 ease-in-out ${
+              showSearchInput ? 'max-h-16 opacity-100' : 'max-h-0 opacity-0'
+            }`}
+          >
+            <div className="relative flex items-center w-full">
+              <input
+                type="text"
+                placeholder="Поиск категорий..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="w-full rounded-md border-gray-300 pl-8 pr-8 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+                autoFocus={showSearchInput} // Auto-focus only when shown
+              />
+              <Search size={16} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400" />
+              {search && (
+                <button
+                  onClick={handleClearSearch}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none"
+                  aria-label="Очистить поиск"
+                >
+                  <X size={16} />
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/EditCategoryModal.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/EditCategoryModal.jsx
@@ -13,19 +13,26 @@ const modalRoot =
 export default function EditCategoryModal({ open, onClose, onSave, category, parents }) {
   const [name, setName] = useState('')
   const [parent, setParent] = useState(null)
+  const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     if (!open || !category) return
     setName(category.name || '')
     setParent(category.parent_id ?? null)
+    setLoading(false)
   }, [open, category])
 
   if (!open || !category) return null
 
-  const handleSave = () => {
+  const handleSave = async () => {
     const val = name.trim()
     if (!val) return
-    onSave({ id: category.id, name: val, parent_id: parent })
+    setLoading(true)
+    try {
+      await onSave({ id: category.id, name: val, parent_id: parent })
+    } finally {
+      setLoading(false)
+    }
   }
 
   return createPortal(
@@ -39,6 +46,7 @@ export default function EditCategoryModal({ open, onClose, onSave, category, par
           value={name}
           onChange={(e) => setName(e.target.value)}
           className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
         />
 
         <label className="mb-1 block text-sm">Родитель</label>
@@ -46,6 +54,7 @@ export default function EditCategoryModal({ open, onClose, onSave, category, par
           value={parent ?? ''}
           onChange={(e) => setParent(e.target.value === '' ? null : Number(e.target.value))}
           className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
         >
           <option value="">Без родителя</option>
           {parents
@@ -60,16 +69,17 @@ export default function EditCategoryModal({ open, onClose, onSave, category, par
         <div className="flex justify-end gap-2">
           <button
             onClick={onClose}
-            className="rounded px-3 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+            disabled={loading}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
           >
             Отмена
           </button>
           <button
-            disabled={!name.trim()}
+            disabled={!name.trim() || loading}
             onClick={handleSave}
             className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
           >
-            Сохранить
+            {loading ? 'Сохранение…' : 'Сохранить'}
           </button>
         </div>
       </div>

--- a/src/pages/Sites/SiteSettings/Products/components/Labels/LabelsList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/Labels/LabelsList.jsx
@@ -1,43 +1,303 @@
 // FILE: src/pages/Sites/SiteSettings/Products/components/Labels/LabelsList.jsx
-import { useState } from 'react'
-import { Plus } from 'lucide-react'
+// (Рекомендуемое имя файла для этого компонента в сайдбаре: LabelsListSidebar.jsx)
 
-export default function LabelsList({ siteName }) {
-  const [labels, setLabels] = useState([
-    { id: 1, name: 'Хит', color: '#ef4444' },
-    { id: 2, name: 'Новинка', color: '#10b981' },
-  ])
+import { useState } from 'react'
+import { Plus, Pencil, Trash, X } from 'lucide-react'
+import { useQuery, useQueryClient } from '@tanstack/react-query' // Удаляем useMutation отсюда, теперь он в хуке
+
+import { useLabelCrud } from '../../hooks/useLabelCrud' // Импортируем новый хук
+
+// --- Компонент модального окна для добавления/редактирования метки ---
+// Это тот же компонент, что и раньше, но теперь он использует хук useLabelCrud
+function LabelFormModal({ isOpen, onClose, siteName, labelToEdit, queryClient }) {
+  const [name, setName] = useState(labelToEdit?.name || '')
+  const [bgColor, setBgColor] = useState(labelToEdit?.bg_color || '#E0E0E0')
+  const [textColor, setTextColor] = useState(labelToEdit?.text_color || '#000000')
+  const [isActive, setIsActive] = useState(labelToEdit?.is_active ?? true)
+  const [sortOrder, setSortOrder] = useState(labelToEdit?.sort_order || 0)
+
+  const { add, update } = useLabelCrud(siteName) // Используем хук CRUD
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    if (!name.trim()) {
+      alert('Название метки не может быть пустым.')
+      return
+    }
+
+    const labelData = {
+      name: name.trim(),
+      bg_color: bgColor,
+      text_color: textColor,
+      is_active: isActive,
+      sort_order: parseInt(sortOrder, 10) || 0
+    }
+
+    if (labelToEdit) {
+      update.mutate({ id: labelToEdit.id, ...labelData }, { // Передаем id и данные
+        onSuccess: () => {
+          onClose();
+        },
+        onError: (error) => {
+          alert(`Ошибка обновления: ${error.message}`);
+        }
+      });
+    } else {
+      add.mutate(labelData, {
+        onSuccess: () => {
+          onClose();
+        },
+        onError: (error) => {
+          alert(`Ошибка создания: ${error.message}`);
+        }
+      });
+    }
+  }
+
+  if (!isOpen) return null
+
+  const isMutating = add.isPending || update.isPending;
 
   return (
-    <div className="space-y-2">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-600 bg-opacity-50">
+      <div className="relative w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 className="mb-4 text-xl font-bold">
+          {labelToEdit ? 'Редактировать метку' : 'Добавить метку'}
+        </h2>
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 text-gray-500 hover:text-gray-700"
+          aria-label="Закрыть"
+        >
+          <X size={24} />
+        </button>
+
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label htmlFor="name" className="mb-1 block text-sm font-medium text-gray-700">Название метки</label>
+            <input
+              type="text"
+              id="name"
+              className="w-full rounded-md border border-gray-300 p-2 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              disabled={isMutating}
+            />
+          </div>
+          <div className="mb-4">
+            <label htmlFor="bgColor" className="mb-1 block text-sm font-medium text-gray-700">Цвет фона</label>
+            <div className="flex items-center gap-2">
+                <input
+                    type="color"
+                    id="bgColor"
+                    className="h-10 w-10 rounded-md border-none p-0"
+                    value={bgColor}
+                    onChange={(e) => setBgColor(e.target.value)}
+                    disabled={isMutating}
+                />
+                <input
+                    type="text"
+                    className="flex-1 rounded-md border border-gray-300 p-2 text-sm"
+                    value={bgColor}
+                    onChange={(e) => setBgColor(e.target.value)}
+                    aria-label="Цвет фона HEX"
+                    disabled={isMutating}
+                />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label htmlFor="textColor" className="mb-1 block text-sm font-medium text-gray-700">Цвет текста</label>
+            <div className="flex items-center gap-2">
+                <input
+                    type="color"
+                    id="textColor"
+                    className="h-10 w-10 rounded-md border-none p-0"
+                    value={textColor}
+                    onChange={(e) => setTextColor(e.target.value)}
+                    disabled={isMutating}
+                />
+                <input
+                    type="text"
+                    className="flex-1 rounded-md border border-gray-300 p-2 text-sm"
+                    value={textColor}
+                    onChange={(e) => setTextColor(e.target.value)}
+                    aria-label="Цвет текста HEX"
+                    disabled={isMutating}
+                />
+            </div>
+          </div>
+          <div className="mb-4 flex items-center">
+            <input
+              type="checkbox"
+              id="isActive"
+              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              checked={isActive}
+              onChange={(e) => setIsActive(e.target.checked)}
+              disabled={isMutating}
+            />
+            <label htmlFor="isActive" className="ml-2 block text-sm text-gray-900">Активно</label>
+          </div>
+          <div className="mb-6">
+            <label htmlFor="sortOrder" className="mb-1 block text-sm font-medium text-gray-700">Порядок сортировки</label>
+            <input
+              type="number"
+              id="sortOrder"
+              className="w-full rounded-md border border-gray-300 p-2 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+              value={sortOrder}
+              onChange={(e) => setSortOrder(e.target.value)}
+              disabled={isMutating}
+            />
+          </div>
+          <div className="flex justify-end space-x-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
+              disabled={isMutating}
+            >
+              Отмена
+            </button>
+            <button
+              type="submit"
+              className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+              disabled={isMutating}
+            >
+              {labelToEdit ? 'Сохранить изменения' : 'Добавить'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+// --- Основной компонент списка меток для сайдбара ---
+export default function LabelsList({ siteName }) {
+  const queryClient = useQueryClient() // Still need queryClient for invalidateQueries manually if needed by parent
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [labelToEdit, setLabelToEdit] = useState(null)
+  const [searchTerm, setSearchTerm] = useState('')
+
+  const { getLabels, remove } = useLabelCrud(siteName) // Используем хук CRUD
+
+  const {
+    data: labels,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['labels', siteName],
+    queryFn: getLabels, // Теперь вызываем getLabels из хука
+  })
+
+  const handleDelete = (id, name) => {
+    if (window.confirm(`Вы уверены, что хотите удалить метку "${name}"? Это действие необратимо.`)) {
+      remove.mutate(id, {
+        onError: (err) => alert(`Ошибка удаления: ${err.message}`),
+      });
+    }
+  }
+
+  const handleEdit = (label) => {
+    setLabelToEdit(label)
+    setIsModalOpen(true)
+  }
+
+  const handleAdd = () => {
+    setLabelToEdit(null) // Сбросить, чтобы добавить новую метку
+    setIsModalOpen(true)
+  }
+
+  const filteredLabels = labels?.filter(label =>
+    label.name.toLowerCase().includes(searchTerm.toLowerCase())
+  )
+
+  if (isLoading) return <div className="p-4 text-gray-500">Загрузка меток...</div>
+  if (isError) return <div className="p-4 text-red-500">Ошибка загрузки меток: {error.message}</div>
+
+  return (
+    <div className="space-y-4 p-2">
       <header className="flex items-center justify-between">
         <h3 className="font-semibold text-sm">Метки товаров</h3>
         <button
           className="flex items-center gap-1 rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
-          onClick={() => alert('Добавить метку (в будущем)')}
+          onClick={handleAdd}
         >
           <Plus size={14} /> Добавить
         </button>
       </header>
 
-      {labels.map(label => (
-        <div
-          key={label.id}
-          className="flex items-center justify-between rounded border px-2 py-1 text-sm"
-          style={{ borderColor: label.color }}
-        >
-          <span className="flex items-center gap-2">
-            <span className="block h-3 w-3 rounded-full" style={{ backgroundColor: label.color }} />
-            {label.name}
-          </span>
-          <button
-            onClick={() => alert(`Настроить метку ${label.name}`)}
-            className="text-xs text-blue-600 hover:underline"
-          >
-            Настроить
-          </button>
+      {/* Поиск */}
+      <div className="mb-4">
+        <input
+          type="text"
+          placeholder="Поиск метки..."
+          className="w-full rounded-md border border-gray-300 p-2 text-sm focus:border-blue-500 focus:ring-blue-500"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+        />
+      </div>
+
+      {filteredLabels && filteredLabels.length > 0 ? (
+        <div className="space-y-2">
+          {filteredLabels.map((label) => (
+            <div
+              key={label.id}
+              className="flex items-center justify-between rounded border px-2 py-2 text-sm"
+              style={{
+                borderColor: label.bg_color,
+                borderLeft: `4px solid ${label.bg_color}`,
+                backgroundColor: label.bg_color + '1A',
+              }}
+            >
+              <span className="flex items-center gap-2" style={{ color: label.text_color }}>
+                <span
+                  className="block h-3 w-3 rounded-full"
+                  style={{ backgroundColor: label.bg_color }}
+                  title={`Фон: ${label.bg_color}`}
+                />
+                {label.name}
+                {/* Опционально: Количество товаров - требуется дополнительный API-запрос или включение в getLabels */}
+                {/* <span className="ml-2 text-xs text-gray-500">(N товаров)</span> */}
+              </span>
+              <div className="flex items-center gap-2">
+                <span
+                    className={`text-xs px-2 py-0.5 rounded-full ${
+                        label.is_active ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+                    }`}
+                >
+                    {label.is_active ? 'Активно' : 'Неактивно'}
+                </span>
+                <button
+                  onClick={() => handleEdit(label)}
+                  className="rounded-md p-1 text-blue-600 hover:bg-blue-100 hover:text-blue-800"
+                  title="Редактировать"
+                >
+                  <Pencil size={16} />
+                </button>
+                <button
+                  onClick={() => handleDelete(label.id, label.name)}
+                  className="rounded-md p-1 text-red-600 hover:bg-red-100 hover:text-red-800"
+                  title="Удалить"
+                >
+                  <Trash size={16} />
+                </button>
+              </div>
+            </div>
+          ))}
         </div>
-      ))}
+      ) : (
+        <div className="text-center text-gray-500">Нет меток. Нажмите "Добавить", чтобы создать новую.</div>
+      )}
+
+      <LabelFormModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        siteName={siteName}
+        labelToEdit={labelToEdit}
+        queryClient={queryClient} // Передаем queryClient в модальное окно
+      />
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/Products/components/Labels/LabelsList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/Labels/LabelsList.jsx
@@ -1,0 +1,43 @@
+// FILE: src/pages/Sites/SiteSettings/Products/components/Labels/LabelsList.jsx
+import { useState } from 'react'
+import { Plus } from 'lucide-react'
+
+export default function LabelsList({ siteName }) {
+  const [labels, setLabels] = useState([
+    { id: 1, name: 'Хит', color: '#ef4444' },
+    { id: 2, name: 'Новинка', color: '#10b981' },
+  ])
+
+  return (
+    <div className="space-y-2">
+      <header className="flex items-center justify-between">
+        <h3 className="font-semibold text-sm">Метки товаров</h3>
+        <button
+          className="flex items-center gap-1 rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+          onClick={() => alert('Добавить метку (в будущем)')}
+        >
+          <Plus size={14} /> Добавить
+        </button>
+      </header>
+
+      {labels.map(label => (
+        <div
+          key={label.id}
+          className="flex items-center justify-between rounded border px-2 py-1 text-sm"
+          style={{ borderColor: label.color }}
+        >
+          <span className="flex items-center gap-2">
+            <span className="block h-3 w-3 rounded-full" style={{ backgroundColor: label.color }} />
+            {label.name}
+          </span>
+          <button
+            onClick={() => alert(`Настроить метку ${label.name}`)}
+            className="text-xs text-blue-600 hover:underline"
+          >
+            Настроить
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductRow.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductRow.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
-import { MoreVertical, Edit2, Trash2 } from 'lucide-react'
+import { MoreVertical, Edit2, Trash2, GripVertical } from 'lucide-react'
+import { Switch } from '@/components/ui/switch'
 
 // преобразуем внутренний/относительный путь в публичный URL
 const toPublicUrl = (raw = '', siteName) => {
@@ -18,6 +19,11 @@ export default function ProductRow({
   onCheck,
   onEdit,
   onDelete,
+  categoryName,
+  dragHandleProps,
+  draggableProps,
+  innerRef,
+  onToggleStatus,
 }) {
   const { domain } = useParams()
   const siteName = `${domain}_app`
@@ -36,7 +42,11 @@ export default function ProductRow({
   const imgSrc = toPublicUrl(product.image_url, siteName)
 
   return (
-    <tr className="hover:bg-gray-50 focus-within:bg-gray-50">
+    <tr
+      ref={innerRef}
+      {...draggableProps}
+      className="hover:bg-gray-50 focus-within:bg-gray-50"
+    >
       <td className="px-2 py-1">
         <input
           type="checkbox"
@@ -45,15 +55,58 @@ export default function ProductRow({
           className="focus:ring-blue-500"
         />
       </td>
+      <td className="px-2 py-1 cursor-grab" {...dragHandleProps}>
+        <GripVertical size={16} className="text-gray-400" />
+      </td>
       <td className="px-2 py-1">
         {imgSrc ? (
-          <img src={imgSrc} alt="" className="h-10 w-10 object-cover rounded" />
+          <img src={imgSrc} alt="" className="h-10 w-10 rounded object-cover" />
         ) : (
-          <div className="h-10 w-10 rounded bg-gray-200 flex items-center justify-center text-xs text-gray-500">—</div>
+          <div className="flex h-10 w-10 items-center justify-center rounded bg-gray-200 text-xs text-gray-500">—</div>
         )}
       </td>
-      <td className="px-2 py-1 text-sm max-w-[240px] truncate">{product.title}</td>
-      <td className="px-2 py-1 text-sm whitespace-nowrap">{product.price}₽</td>
+      <td className="max-w-[240px] truncate px-2 py-1 text-sm">
+        {product.title}
+        {product.slug && (
+          <div className="text-xs text-gray-500">{product.slug}</div>
+        )}
+      </td>
+      <td className="px-2 py-1 whitespace-nowrap">
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={Boolean(product.active)}
+            onCheckedChange={(val) => onToggleStatus(product.id, { active: val })}
+          />
+          {product.is_available !== undefined && (
+            <Switch
+              checked={Boolean(product.is_available)}
+              onCheckedChange={(val) =>
+                onToggleStatus(product.id, { is_available: val })
+              }
+            />
+          )}
+        </div>
+      </td>
+      <td className="px-2 py-1 whitespace-nowrap text-sm">
+        {product.price}₽{' '}
+        {product.old_price && (
+          <s className="text-gray-400">{product.old_price}₽</s>
+        )}
+      </td>
+      <td className="px-2 py-1 text-sm">
+        {product.labels?.map((lb) => (
+          <span
+            key={lb}
+            className="mr-1 rounded bg-blue-100 px-1 text-xs text-blue-800"
+          >
+            {lb}
+          </span>
+        ))}
+      </td>
+      <td className="px-2 py-1 text-sm">{categoryName || '—'}</td>
+      <td className="px-2 py-1 text-sm whitespace-nowrap">
+        {product.weight || '—'}
+      </td>
       <td className="relative px-2 py-1 text-right">
         <button
           className="rounded p-1 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductRow.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductRow.jsx
@@ -72,20 +72,16 @@ export default function ProductRow({
         )}
       </td>
       <td className="px-2 py-1 whitespace-nowrap">
-        <div className="flex items-center gap-2">
-          <Switch
-            checked={Boolean(product.active)}
-            onCheckedChange={(val) => onToggleStatus(product.id, { active: val })}
-          />
-          {product.is_available !== undefined && (
-            <Switch
-              checked={Boolean(product.is_available)}
-              onCheckedChange={(val) =>
-                onToggleStatus(product.id, { is_available: val })
-              }
-            />
-          )}
-        </div>
+        <Switch
+          checked={Boolean(product.active)}
+          onCheckedChange={(val) => onToggleStatus(product.id, { active: val })}
+        />
+      </td>
+      <td className="px-2 py-1 whitespace-nowrap">
+        <Switch
+          checked={Boolean(product.is_available)}
+          onCheckedChange={(val) => onToggleStatus(product.id, { is_available: val })}
+        />
       </td>
       <td className="px-2 py-1 whitespace-nowrap text-sm">
         {product.price}₽{' '}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductTable.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductTable.jsx
@@ -21,7 +21,7 @@ export default function ProductTable({
         <tbody>
           {Array.from({ length: 5 }).map((_, i) => (
             <tr key={i} className="animate-pulse border-t">
-              <td className="px-2 py-3" colSpan={10}>
+              <td className="px-2 py-3" colSpan={11}>
                 <div className="h-4 w-full rounded bg-gray-200" />
               </td>
             </tr>
@@ -34,7 +34,7 @@ export default function ProductTable({
       return (
         <tbody>
           <tr>
-            <td colSpan={10} className="py-6 text-center text-sm text-gray-500">
+            <td colSpan={11} className="py-6 text-center text-sm text-gray-500">
               Вы ещё не добавили ни одного товара
               <div className="mt-2">
                 <button
@@ -101,7 +101,8 @@ export default function ProductTable({
           <th className="w-4 px-2 py-1" />
           <th className="w-12 px-2 py-1">Фото</th>
           <th className="px-2 py-1">Название / SKU</th>
-          <th className="px-2 py-1">Статус</th>
+          <th className="px-2 py-1">Активен</th>
+          <th className="px-2 py-1">В наличии</th>
           <th className="px-2 py-1">Цена</th>
           <th className="px-2 py-1">Метки</th>
           <th className="px-2 py-1">Категория</th>
@@ -113,4 +114,3 @@ export default function ProductTable({
     </table>
   )
 }
-

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductTable.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductTable.jsx
@@ -1,4 +1,5 @@
 import ProductRow from './ProductRow'
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd'
 
 export default function ProductTable({
   isFetching,
@@ -10,6 +11,9 @@ export default function ProductTable({
   onEdit,
   onDelete,
   onAdd,
+  categoryMap,
+  onReorder,
+  onToggleStatus,
 }) {
   const renderBody = () => {
     if (isFetching) {
@@ -17,7 +21,7 @@ export default function ProductTable({
         <tbody>
           {Array.from({ length: 5 }).map((_, i) => (
             <tr key={i} className="animate-pulse border-t">
-              <td className="px-2 py-3" colSpan={5}>
+              <td className="px-2 py-3" colSpan={10}>
                 <div className="h-4 w-full rounded bg-gray-200" />
               </td>
             </tr>
@@ -30,7 +34,7 @@ export default function ProductTable({
       return (
         <tbody>
           <tr>
-            <td colSpan={5} className="py-6 text-center text-sm text-gray-500">
+            <td colSpan={10} className="py-6 text-center text-sm text-gray-500">
               Вы ещё не добавили ни одного товара
               <div className="mt-2">
                 <button
@@ -47,18 +51,38 @@ export default function ProductTable({
     }
 
     return (
-      <tbody>
-        {pageItems.map((p) => (
-          <ProductRow
-            key={p.id}
-            product={p}
-            checked={selected.has(p.id)}
-            onCheck={toggleSelect}
-            onEdit={onEdit}
-            onDelete={onDelete}
-          />
-        ))}
-      </tbody>
+      <DragDropContext
+        onDragEnd={({ source, destination }) => {
+          if (!destination || source.index === destination.index) return
+          onReorder(source.index, destination.index)
+        }}
+      >
+        <Droppable droppableId="products">
+          {(prov) => (
+            <tbody ref={prov.innerRef} {...prov.droppableProps}>
+              {pageItems.map((p, index) => (
+                <Draggable key={p.id} draggableId={String(p.id)} index={index}>
+                  {(prov2) => (
+                    <ProductRow
+                      innerRef={prov2.innerRef}
+                      draggableProps={prov2.draggableProps}
+                      dragHandleProps={prov2.dragHandleProps}
+                      product={p}
+                      checked={selected.has(p.id)}
+                      onCheck={toggleSelect}
+                      onEdit={onEdit}
+                      onDelete={onDelete}
+                      categoryName={categoryMap[p.category_id]}
+                      onToggleStatus={onToggleStatus}
+                    />
+                  )}
+                </Draggable>
+              ))}
+              {prov.placeholder}
+            </tbody>
+          )}
+        </Droppable>
+      </DragDropContext>
     )
   }
 
@@ -74,9 +98,14 @@ export default function ProductTable({
               className="focus:ring-blue-500"
             />
           </th>
+          <th className="w-4 px-2 py-1" />
           <th className="w-12 px-2 py-1">Фото</th>
-          <th className="px-2 py-1">Название</th>
+          <th className="px-2 py-1">Название / SKU</th>
+          <th className="px-2 py-1">Статус</th>
           <th className="px-2 py-1">Цена</th>
+          <th className="px-2 py-1">Метки</th>
+          <th className="px-2 py-1">Категория</th>
+          <th className="px-2 py-1">Вес</th>
           <th className="px-2 py-1" />
         </tr>
       </thead>
@@ -84,3 +113,4 @@ export default function ProductTable({
     </table>
   )
 }
+

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductTable.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductTable.jsx
@@ -1,5 +1,9 @@
+import { useState } from 'react'
 import ProductRow from './ProductRow'
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd'
+import AddCategoryModal from '../AddCategoryModal'
+import { useCategoryCrud } from '../CategoryList/useCategoryCrud'
+import { useParams } from 'react-router-dom'
 
 export default function ProductTable({
   isFetching,
@@ -15,6 +19,13 @@ export default function ProductTable({
   onReorder,
   onToggleStatus,
 }) {
+  const hasCategories = Object.keys(categoryMap).length > 0
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
+
+  const { add: addCat } = useCategoryCrud(siteName)
+  const [showAddCat, setShowAddCat] = useState(false)
+
   const renderBody = () => {
     if (isFetching) {
       return (
@@ -35,15 +46,31 @@ export default function ProductTable({
         <tbody>
           <tr>
             <td colSpan={11} className="py-6 text-center text-sm text-gray-500">
-              Вы ещё не добавили ни одного товара
-              <div className="mt-2">
-                <button
-                  onClick={onAdd}
-                  className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
-                >
-                  Добавить первый товар
-                </button>
-              </div>
+              {!hasCategories ? (
+                <>
+                  Сначала создайте категории товаров (например: Пицца, Напитки)
+                  <div className="mt-2">
+                    <button
+                      onClick={() => setShowAddCat(true)}
+                      className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+                    >
+                      Добавить категорию
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  Вы ещё не добавили ни одного товара
+                  <div className="mt-2">
+                    <button
+                      onClick={onAdd}
+                      className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+                    >
+                      Добавить первый товар
+                    </button>
+                  </div>
+                </>
+              )}
             </td>
           </tr>
         </tbody>
@@ -87,30 +114,42 @@ export default function ProductTable({
   }
 
   return (
-    <table className="w-full border text-left text-sm">
-      <thead className="bg-gray-100">
-        <tr>
-          <th className="w-8 px-2 py-1">
-            <input
-              type="checkbox"
-              onChange={toggleSelectAll}
-              checked={pageItems.length > 0 && pageItems.every((p) => selected.has(p.id))}
-              className="focus:ring-blue-500"
-            />
-          </th>
-          <th className="w-4 px-2 py-1" />
-          <th className="w-12 px-2 py-1">Фото</th>
-          <th className="px-2 py-1">Название / SKU</th>
-          <th className="px-2 py-1">Активен</th>
-          <th className="px-2 py-1">В наличии</th>
-          <th className="px-2 py-1">Цена</th>
-          <th className="px-2 py-1">Метки</th>
-          <th className="px-2 py-1">Категория</th>
-          <th className="px-2 py-1">Вес</th>
-          <th className="px-2 py-1" />
-        </tr>
-      </thead>
-      {renderBody()}
-    </table>
+    <>
+      <table className="w-full border text-left text-sm">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="w-8 px-2 py-1">
+              <input
+                type="checkbox"
+                onChange={toggleSelectAll}
+                checked={pageItems.length > 0 && pageItems.every((p) => selected.has(p.id))}
+                className="focus:ring-blue-500"
+              />
+            </th>
+            <th className="w-4 px-2 py-1" />
+            <th className="w-12 px-2 py-1">Фото</th>
+            <th className="px-2 py-1">Название / SKU</th>
+            <th className="px-2 py-1">Активен</th>
+            <th className="px-2 py-1">В наличии</th>
+            <th className="px-2 py-1">Цена</th>
+            <th className="px-2 py-1">Метки</th>
+            <th className="px-2 py-1">Категория</th>
+            <th className="px-2 py-1">Вес</th>
+            <th className="px-2 py-1" />
+          </tr>
+        </thead>
+        {renderBody()}
+      </table>
+
+      <AddCategoryModal
+        open={showAddCat}
+        onClose={() => setShowAddCat(false)}
+        onSave={async (payload) => {
+          await addCat.mutateAsync(payload)
+          setShowAddCat(false)
+        }}
+        parents={[]} // если в будущем нужны иерархии — прокинь сюда дерево
+      />
+    </>
   )
 }

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
@@ -88,7 +88,7 @@ export default function ProductsList({ category }) {
       {list.selected.size ? (
         <BulkActionsBar count={list.selected.size} onDelete={list.deleteSelected} />
       ) : (
-        <Toolbar onAdd={() => setShowAdd(true)} search={list.search} onSearch={list.setSearch} />
+        <Toolbar onAdd={() => setShowAdd(true)} search={list.search} onSearch={list.setSearch} disabledAdd={!Object.keys(categoryMap).length} />
       )}
 
       <ProductTable

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 
 import { useProducts } from '../../hooks/useProducts'
 import { useProductCrud } from '../../hooks/useProductCrud'
-import { useCategories } from '../../hooks/useCategories' // ✅ добавлен импорт
+import { useCategories } from '../../hooks/useCategories'
 
 import AddProductModal from '../AddProductModal'
 import EditProductModal from '../EditProductModal'
@@ -22,8 +22,14 @@ export default function ProductsList({ category }) {
   const { data: tree = [] } = useCategories(siteName)
 
   const [ordered, setOrdered] = useState([])
+
   useEffect(() => {
-    setOrdered(all)
+    setOrdered(prev => {
+      if (JSON.stringify(prev) !== JSON.stringify(all)) {
+        return all
+      }
+      return prev
+    })
   }, [all])
 
   const categoryMap = useMemo(() => {
@@ -123,4 +129,3 @@ export default function ProductsList({ category }) {
     </div>
   )
 }
-

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/Toolbar.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/Toolbar.jsx
@@ -1,11 +1,12 @@
 import { Plus } from 'lucide-react'
 
-export default function Toolbar({ onAdd, search, onSearch }) {
+export default function Toolbar({ onAdd, search, onSearch, disabledAdd }) {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <button
         onClick={onAdd}
-        className="flex items-center gap-1 rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+        disabled={disabledAdd}
+        className="flex items-center gap-1 rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed focus:ring-2 focus:ring-blue-500"
       >
         <Plus size={16} /> Добавить товар
       </button>

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/useProductsList.js
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/useProductsList.js
@@ -24,7 +24,7 @@ function getAllNestedCategoryIds(rootId, categories = []) {
   return ids
 }
 
-export default function useProductsList({ products = [], category, categories = [], removeFn }) {
+export default function useProductsList({ products = [], category, labels, categories = [], removeFn }) {
   const [search, setSearch] = useState('')
   const [debounced, setDebounced] = useState('')
   const [selected, setSelected] = useState(new Set())
@@ -47,12 +47,18 @@ export default function useProductsList({ products = [], category, categories = 
       list = list.filter((p) => allowedIds.has(Number(p.category_id)))
     }
 
+    if (labels?.length) {
+      list = list.filter((p) =>
+        Array.isArray(p.labels) && labels.some((id) => p.labels.includes(id))
+      )
+    }
+
     if (debounced) {
       list = list.filter((p) => p.title.toLowerCase().includes(debounced))
     }
 
     return list
-  }, [products, category, debounced, flatCategories])
+  }, [products, category, labels, debounced, flatCategories])
 
   // ─── Пагинация ───────────────────────────────────────────────
   const pageSize = 10

--- a/src/pages/Sites/SiteSettings/Products/hooks/useLabelCrud.js
+++ b/src/pages/Sites/SiteSettings/Products/hooks/useLabelCrud.js
@@ -1,0 +1,88 @@
+// FILE: src/pages/Sites/SiteSettings/Products/hooks/useLabelCrud.js
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useLabelCrud(siteName) {
+  const qc = useQueryClient()
+
+  /* CREATE ------------------------------------------------------------------ */
+  const add = useMutation({
+    mutationFn: async (labelData) => {
+      const res = await fetch(
+        `${API_URL}/products/${siteName}/labels/add`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(labelData),
+        },
+      )
+      if (!res.ok) {
+        const errorData = await res.json();
+        throw new Error(errorData.message || 'Ошибка создания метки');
+      }
+      // Бэкенд возвращает {"message": "...", "site_response": ...}
+      return res.json(); // Возвращаем весь ответ, React Query сам обработает его
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['labels', siteName] }),
+  })
+
+  /* UPDATE ------------------------------------------------------------------ */
+  const update = useMutation({
+    mutationFn: async ({ id, ...labelData }) => {
+      const res = await fetch(
+        `${API_URL}/products/${siteName}/labels/update/${id}`, // label_id
+        {
+          method: 'PATCH',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(labelData),
+        },
+      )
+      if (!res.ok) {
+        const errorData = await res.json();
+        throw new Error(errorData.message || 'Ошибка обновления метки');
+      }
+      // Бэкенд возвращает {"message": "...", "site_response": ...}
+      return res.json();
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['labels', siteName] });
+    },
+  })
+
+  /* DELETE ------------------------------------------------------------------ */
+  const remove = useMutation({
+    mutationFn: async (id) => {
+      const res = await fetch(
+        `${API_URL}/products/${siteName}/labels/delete/${id}`, // label_id
+        { method: 'DELETE', credentials: 'include' },
+      )
+      if (!res.ok) {
+        const errorData = await res.json();
+        throw new Error(errorData.message || 'Ошибка удаления метки');
+      }
+      // Бэкенд возвращает {"message": "...", "site_response": ...}
+      return res.json();
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['labels', siteName] }),
+  })
+
+  /* FETCH ALL LABELS -------------------------------------------------------- */
+  const getLabels = async () => {
+    // ИСПРАВЛЕНИЕ: Изменен эндпоинт для получения всех меток
+    const res = await fetch(`${API_URL}/products/${siteName}/labels/all`, {
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      const errorData = await res.json();
+      throw new Error(errorData.message || 'Ошибка загрузки меток');
+    }
+    // Бэкенд возвращает чистый массив меток для 'all' эндпоинта
+    return res.json();
+  };
+
+
+  return { add, update, remove, getLabels }
+}

--- a/src/pages/Sites/SiteSettings/Products/index.jsx
+++ b/src/pages/Sites/SiteSettings/Products/index.jsx
@@ -1,26 +1,45 @@
-// FILE: src/pages/Sites/SiteSettings/Products/index.jsx
 import { useRef, useState } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { useParams } from 'react-router-dom'
+
 import CategoryList from './components/CategoryList/CategoryList'
 import ProductsList from './components/ProductsList/ProductsList'
 
 export default function Products() {
   const queryClientRef = useRef(new QueryClient())
   const [selectedCategory, setSelectedCategory] = useState(null)
+  const [tab, setTab] = useState('categories')
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
 
   return (
     <QueryClientProvider client={queryClientRef.current}>
-      <div className="flex h-full">
-        <aside className="w-64 border-r bg-white p-4">
-          <CategoryList
-            selected={selectedCategory}
-            onSelect={setSelectedCategory}
-          />
-        </aside>
-        <main className="flex-1 overflow-auto p-4">
-          <ProductsList category={selectedCategory} />
-        </main>
+      <div className="h-full p-4">
+        {tab === 'categories' ? (
+          <div className="flex h-full">
+            <aside className="w-64 border-r bg-white p-4">
+              <CategoryList
+                selected={selectedCategory}
+                onSelect={setSelectedCategory}
+                tab={tab}
+                setTab={setTab}
+              />
+            </aside>
+            <main className="flex-1 overflow-auto p-4">
+              <ProductsList category={selectedCategory} />
+            </main>
+          </div>
+        ) : (
+          <div className="bg-white rounded shadow p-4 h-full overflow-auto">
+            <CategoryList
+              selected={selectedCategory}
+              onSelect={setSelectedCategory}
+              tab={tab}
+              setTab={setTab}
+            />
+          </div>
+        )}
       </div>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/src/pages/Sites/SiteSettings/Products/index.jsx
+++ b/src/pages/Sites/SiteSettings/Products/index.jsx
@@ -16,7 +16,7 @@ export default function Products() {
   return (
     <QueryClientProvider client={queryClientRef.current}>
       <div className="h-full p-4">
-        {tab === 'categories' ? (
+        {(tab === 'categories' || tab === 'labels') ? (
           <div className="flex h-full">
             <aside className="w-64 border-r bg-white p-4">
               <CategoryList
@@ -27,19 +27,13 @@ export default function Products() {
               />
             </aside>
             <main className="flex-1 overflow-auto p-4">
-              <ProductsList category={selectedCategory} />
+              <ProductsList
+                category={tab === 'categories' ? selectedCategory : null}
+                labels={tab === 'labels' ? selectedCategory : null}
+              />
             </main>
           </div>
-        ) : (
-          <div className="bg-white rounded shadow p-4 h-full overflow-auto">
-            <CategoryList
-              selected={selectedCategory}
-              onSelect={setSelectedCategory}
-              tab={tab}
-              setTab={setTab}
-            />
-          </div>
-        )}
+        ) : null}
       </div>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>


### PR DESCRIPTION
## Summary
- add drag-n-drop support and many new columns in products table
- show product slug, status toggles, labels, category and weight
- keep list of products reorderable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852a2f5503083319df55dfd3953402e