### PR TITLE
Add labels CRUD UI

### DIFF
--- a/src/pages/Sites/SiteSettings/Products/components/Labels/AddLabelModal.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/Labels/AddLabelModal.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function AddLabelModal({ open, onClose, onSave }) {
+  const [name, setName] = useState('')
+  const [color, setColor] = useState('#000000')
+  const [description, setDescription] = useState('')
+  const [active, setActive] = useState(true)
+
+  useEffect(() => {
+    if (!open) {
+      setName('')
+      setColor('#000000')
+      setDescription('')
+      setActive(true)
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const handleSave = () => {
+    const val = name.trim()
+    if (!val) return
+    onSave({
+      name: val,
+      color,
+      description: description.trim() || undefined,
+      is_active: active,
+    })
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl space-y-2">
+        <h3 className="text-lg font-medium">Новая метка</h3>
+
+        <label className="block text-sm">Название</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="block text-sm">Цвет</label>
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          className="h-8 w-full rounded border"
+        />
+
+        <label className="block text-sm">Описание</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={active}
+            onChange={(e) => setActive(e.target.checked)}
+            className="focus:ring-blue-500"
+          />
+          Активна
+        </label>
+
+        <div className="flex justify-end gap-2 pt-1">
+          <button
+            onClick={onClose}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!name.trim()}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Сохранить
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/Labels/EditLabelModal.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/Labels/EditLabelModal.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function EditLabelModal({ open, onClose, onSave, label }) {
+  const [name, setName] = useState('')
+  const [color, setColor] = useState('#000000')
+  const [description, setDescription] = useState('')
+  const [active, setActive] = useState(true)
+
+  useEffect(() => {
+    if (!open || !label) return
+    setName(label.name || '')
+    setColor(label.color || '#000000')
+    setDescription(label.description || '')
+    setActive(label.is_active)
+  }, [open, label])
+
+  if (!open || !label) return null
+
+  const handleSave = () => {
+    const val = name.trim()
+    if (!val) return
+    onSave({
+      id: label.id,
+      name: val,
+      color,
+      description: description.trim() || undefined,
+      is_active: active,
+    })
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl space-y-2">
+        <h3 className="text-lg font-medium">Редактировать метку</h3>
+
+        <label className="block text-sm">Название</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="block text-sm">Цвет</label>
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          className="h-8 w-full rounded border"
+        />
+
+        <label className="block text-sm">Описание</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={active}
+            onChange={(e) => setActive(e.target.checked)}
+            className="focus:ring-blue-500"
+          />
+          Активна
+        </label>
+
+        <div className="flex justify-end gap-2 pt-1">
+          <button
+            onClick={onClose}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!name.trim()}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Сохранить
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/Labels/LabelsList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/Labels/LabelsList.jsx
@@ -1,12 +1,19 @@
 // FILE: src/pages/Sites/SiteSettings/Products/components/Labels/LabelsList.jsx
 import { useState } from 'react'
-import { Plus } from 'lucide-react'
+import { Plus, Pencil, Trash2 } from 'lucide-react'
+
+import { useLabels } from '../../hooks/useLabels'
+import { useLabelCrud } from './useLabelCrud'
+import AddLabelModal from './AddLabelModal'
+import EditLabelModal from './EditLabelModal'
 
 export default function LabelsList({ siteName }) {
-  const [labels, setLabels] = useState([
-    { id: 1, name: 'Хит', color: '#ef4444' },
-    { id: 2, name: 'Новинка', color: '#10b981' },
-  ])
+  const { data: labels = [], isFetching } = useLabels(siteName)
+  const { add: addLabel, update: updateLabel, remove: deleteLabel } =
+    useLabelCrud(siteName)
+
+  const [showAdd, setShowAdd] = useState(false)
+  const [editState, setEditState] = useState({ open: false, label: null })
 
   return (
     <div className="space-y-2">
@@ -14,30 +21,73 @@ export default function LabelsList({ siteName }) {
         <h3 className="font-semibold text-sm">Метки товаров</h3>
         <button
           className="flex items-center gap-1 rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
-          onClick={() => alert('Добавить метку (в будущем)')}
+          onClick={() => setShowAdd(true)}
         >
           <Plus size={14} /> Добавить
         </button>
       </header>
 
-      {labels.map(label => (
-        <div
-          key={label.id}
-          className="flex items-center justify-between rounded border px-2 py-1 text-sm"
-          style={{ borderColor: label.color }}
-        >
-          <span className="flex items-center gap-2">
-            <span className="block h-3 w-3 rounded-full" style={{ backgroundColor: label.color }} />
-            {label.name}
-          </span>
+      {labels.length === 0 && !isFetching ? (
+        <div className="rounded border border-dashed p-4 text-center">
+          <p className="mb-2 text-sm text-gray-600">Вы ещё не добавили ни одной метки</p>
           <button
-            onClick={() => alert(`Настроить метку ${label.name}`)}
-            className="text-xs text-blue-600 hover:underline"
+            onClick={() => setShowAdd(true)}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
           >
-            Настроить
+            Добавить первую метку
           </button>
         </div>
-      ))}
+      ) : (
+        labels.map(label => (
+          <div
+            key={label.id}
+            className={`flex items-center justify-between rounded border px-2 py-1 text-sm ${!label.is_active ? 'opacity-50' : ''}`}
+            style={{ borderColor: label.color }}
+          >
+            <span className="flex items-center gap-2">
+              <span className="block h-3 w-3 rounded-full" style={{ backgroundColor: label.color }} />
+              {label.name}
+            </span>
+            <span className="flex gap-1">
+              <Pencil
+                size={14}
+                className="cursor-pointer hover:text-blue-600"
+                onClick={() => setEditState({ open: true, label })}
+              />
+              <Trash2
+                size={14}
+                className="cursor-pointer hover:text-red-600"
+                onClick={() =>
+                  window.confirm(`Удалить «${label.name}»?`) && deleteLabel.mutateAsync(label.id)
+                }
+              />
+            </span>
+          </div>
+        ))
+      )}
+
+      <AddLabelModal
+        open={showAdd}
+        onClose={() => setShowAdd(false)}
+        onSave={async payload => {
+          await addLabel.mutateAsync(payload)
+          setShowAdd(false)
+        }}
+      />
+
+      <EditLabelModal
+        open={editState.open}
+        label={editState.label}
+        onClose={() => setEditState({ open: false, label: null })}
+        onSave={async payload => {
+          await updateLabel.mutateAsync(payload)
+          setEditState({ open: false, label: null })
+        }}
+      />
+
+      {isFetching && (
+        <div className="text-center text-xs text-gray-500">Загрузка…</div>
+      )}
     </div>
   )
 }

--- a/src/pages/Sites/SiteSettings/Products/components/Labels/useLabelCrud.js
+++ b/src/pages/Sites/SiteSettings/Products/components/Labels/useLabelCrud.js
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useLabelCrud(siteName) {
+  const qc = useQueryClient()
+
+  const add = useMutation({
+    mutationFn: async ({ name, color, description, is_active }) => {
+      const body = { name, color, description, is_active }
+      const res = await fetch(
+        `${API_URL}/products/${siteName}/labels/add`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+      )
+      if (!res.ok) throw new Error('Ошибка создания метки')
+      return res.json()
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['labels', siteName] }),
+  })
+
+  const update = useMutation({
+    mutationFn: async ({ id, name, color, description, is_active }) => {
+      const body = { name, color, description, is_active }
+      const res = await fetch(
+        `${API_URL}/products/${siteName}/labels/update/${id}`,
+        {
+          method: 'PATCH',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+      )
+      if (!res.ok) throw new Error('Ошибка обновления метки')
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['labels', siteName] }),
+  })
+
+  const remove = useMutation({
+    mutationFn: async (id) => {
+      const res = await fetch(
+        `${API_URL}/products/${siteName}/labels/delete/${id}`,
+        { method: 'DELETE', credentials: 'include' },
+      )
+      if (!res.ok) throw new Error('Ошибка удаления метки')
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['labels', siteName] }),
+  })
+
+  return { add, update, remove }
+}

--- a/src/pages/Sites/SiteSettings/Products/hooks/useLabels.js
+++ b/src/pages/Sites/SiteSettings/Products/hooks/useLabels.js
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useLabels(siteName, options = {}) {
+  return useQuery({
+    queryKey: ['labels', siteName],
+    queryFn: async () => {
+      const res = await fetch(
+        `${API_URL}/products/${siteName}/labels`,
+        { credentials: 'include' },
+      )
+      if (!res.ok) throw new Error('Не удалось получить метки')
+      return res.json()
+    },
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}


### PR DESCRIPTION
## Summary
- implement labels CRUD via React Query
- add label modals for create and edit
- show labels list with edit/delete buttons and add first label button
- fetch labels from backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852d428bf988331b4f01fb348d891d2