### PR TITLE
Inline edit for product categories and labels

### DIFF
--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/EditableLabelTags.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/EditableLabelTags.jsx
@@ -1,0 +1,69 @@
+import { useState, useRef, useEffect } from 'react'
+
+export default function EditableLabelTags({ value = [], labelsList, labelsMap, onSave }) {
+  const [open, setOpen] = useState(false)
+  const [selected, setSelected] = useState(value)
+  const wrapperRef = useRef(null)
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+        setOpen(false)
+        if (JSON.stringify(selected) !== JSON.stringify(value)) {
+          onSave(selected)
+        }
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [selected, value, onSave])
+
+  const toggle = (id) => {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((l) => l !== id) : [...prev, id]
+    )
+  }
+
+  return (
+    <div
+      ref={wrapperRef}
+      className="relative text-xs"
+      onClick={() => setOpen(true)}
+    >
+      <div className="flex flex-wrap gap-1 cursor-pointer">
+        {value.length
+          ? value.map((lb) => {
+              const l = labelsMap[lb] || {}
+              return (
+                <span
+                  key={lb}
+                  className="rounded px-1"
+                  style={{
+                    backgroundColor: l.bg_color || '#e5e7eb',
+                    color: l.text_color || '#111827',
+                  }}
+                >
+                  {l.name || lb}
+                </span>
+              )
+            })
+          : <span className="text-gray-400">—</span>}
+      </div>
+
+      {open && (
+        <div className="absolute z-10 mt-1 w-40 max-h-40 overflow-auto rounded border bg-white p-2 shadow-lg">
+          {labelsList.map((l) => (
+            <label key={l.id} className="flex items-center gap-2 text-xs py-0.5">
+              <input
+                type="checkbox"
+                checked={selected.includes(String(l.id))}
+                onChange={() => toggle(String(l.id))}
+              />
+              <span>{l.name}</span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductRow.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductRow.jsx
@@ -1,8 +1,9 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { Edit2, Trash2, GripVertical } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
 import slugify from 'slugify'
+import EditableLabelTags from './EditableLabelTags'
 
 const toPublicUrl = (raw = '', siteName) => {
   if (!raw) return null
@@ -39,8 +40,6 @@ export default function ProductRow({
   const [weightVal, setWeightVal] = useState('')
   const [editCategory, setEditCategory] = useState(false)
   const [categoryVal, setCategoryVal] = useState('')
-  const [editLabels, setEditLabels] = useState(false)
-  const [labelsVal, setLabelsVal] = useState([])
 
   const getFullPayload = (changes = {}) => ({
     id: product.id,
@@ -96,14 +95,6 @@ export default function ProductRow({
     setEditCategory(false)
     if (categoryVal && categoryVal !== String(product.category_id)) {
       await onInlineUpdate(product.id, getFullPayload({ category_id: categoryVal }))
-    }
-  }
-
-  const saveLabels = async () => {
-    setEditLabels(false)
-    const original = Array.isArray(product.labels) ? product.labels : []
-    if (JSON.stringify(original) !== JSON.stringify(labelsVal)) {
-      await onInlineUpdate(product.id, getFullPayload({ labels: labelsVal }))
     }
   }
 
@@ -165,7 +156,7 @@ export default function ProductRow({
         <Switch
           className="data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-gray-200"
           checked={Boolean(product.active)}
-          onCheckedChange={(val) => 
+          onCheckedChange={(val) =>
             onToggleStatus(product.id, getFullPayload({ active: val }))
           }
         />
@@ -174,7 +165,7 @@ export default function ProductRow({
         <Switch
           className="data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-gray-200"
           checked={Boolean(product.is_available)}
-          onCheckedChange={(val) => 
+          onCheckedChange={(val) =>
             onToggleStatus(product.id, getFullPayload({ is_available: val }))
           }
         />
@@ -208,51 +199,15 @@ export default function ProductRow({
           </>
         )}
       </td>
-      <td
-        className="px-2 py-1 text-sm"
-        onDoubleClick={() => {
-          setLabelsVal(Array.isArray(product.labels) ? product.labels.map(String) : [])
-          setEditLabels(true)
-        }}
-      >
-        {editLabels ? (
-          <select
-            multiple
-            autoFocus
-            value={labelsVal}
-            onChange={(e) =>
-              setLabelsVal(Array.from(e.target.selectedOptions).map((o) => o.value))
-            }
-            onBlur={saveLabels}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') saveLabels()
-              if (e.key === 'Escape') setEditLabels(false)
-            }}
-            className="w-40 rounded border px-1 text-xs focus:ring-2 focus:ring-blue-500"
-            size={Math.min(labelsList.length, 4) || 4}
-          >
-            {labelsList.map((l) => (
-              <option key={l.id} value={l.id}>
-                {l.name}
-              </option>
-            ))}
-          </select>
-        ) : (
-          <div className="flex flex-wrap gap-1 text-xs">
-            {product.labels?.map((lb) => {
-              const l = labelsMap[lb] || {}
-              return (
-                <span
-                  key={lb}
-                  className="rounded px-1"
-                  style={{ backgroundColor: l.bg_color || '#e5e7eb', color: l.text_color || '#111827' }}
-                >
-                  {l.name || lb}
-                </span>
-              )
-            })}
-          </div>
-        )}
+      <td className="px-2 py-1 text-sm">
+        <EditableLabelTags
+          value={Array.isArray(product.labels) ? product.labels.map(String) : []}
+          labelsList={labelsList}
+          labelsMap={labelsMap}
+          onSave={(newLabels) =>
+            onInlineUpdate(product.id, getFullPayload({ labels: newLabels }))
+          }
+        />
       </td>
       <td
         className="px-2 py-1 text-sm"

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductTable.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductTable.jsx
@@ -16,6 +16,9 @@ export default function ProductTable({
   onDelete,
   onAdd,
   categoryMap,
+  categoryOptions,
+  labelsMap,
+  labelsList,
   onReorder,
   onToggleStatus,
   onInlineUpdate,
@@ -104,6 +107,9 @@ export default function ProductTable({
                     onEdit={onEdit}
                     onDelete={onDelete}
                     categoryName={categoryMap[p.category_id]}
+                    categoryOptions={categoryOptions}
+                    labelsMap={labelsMap}
+                    labelsList={labelsList}
                     onToggleStatus={onToggleStatus}
                     onInlineUpdate={onInlineUpdate}
                   />

--- a/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
+++ b/src/pages/Sites/SiteSettings/Products/components/ProductsList/ProductsList.jsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom'
 import { useProducts } from '../../hooks/useProducts'
 import { useProductCrud } from '../../hooks/useProductCrud'
 import { useCategories } from '../../hooks/useCategories'
+import { useLabels } from '../../hooks/useLabels'
 
 import AddProductModal from '../AddProductModal'
 import EditProductModal from '../EditProductModal'
@@ -20,6 +21,7 @@ export default function ProductsList({ category, labels, noLabel }) {
   const { data: all = [], isFetching, isError, refetch } = useProducts(siteName)
   const { add, update, remove } = useProductCrud(siteName)
   const { data: tree = [] } = useCategories(siteName)
+  const { data: labelsList = [] } = useLabels(siteName)
 
   const [ordered, setOrdered] = useState([])
 
@@ -43,6 +45,27 @@ export default function ProductsList({ category, labels, noLabel }) {
     walk(tree)
     return map
   }, [tree])
+
+  const categoryOptions = useMemo(() => {
+    const list = []
+    const walk = (nodes, prefix = '') => {
+      nodes.forEach((n) => {
+        const path = prefix ? `${prefix} / ${n.name}` : n.name
+        list.push({ id: n.id, path })
+        if (n.children?.length) walk(n.children, path)
+      })
+    }
+    walk(tree)
+    return list
+  }, [tree])
+
+  const labelsMap = useMemo(() => {
+    const map = {}
+    labelsList.forEach((l) => {
+      map[l.id] = l
+    })
+    return map
+  }, [labelsList])
 
   const list = useProductsList({
     products: ordered,
@@ -132,6 +155,9 @@ export default function ProductsList({ category, labels, noLabel }) {
         onDelete={id => remove.mutateAsync(id)}
         onAdd={() => setShowAdd(true)}
         categoryMap={categoryMap}
+        categoryOptions={categoryOptions}
+        labelsMap={labelsMap}
+        labelsList={labelsList}
         onReorder={handleReorder}
         onToggleStatus={handleToggleStatus}
         onInlineUpdate={handleInlineUpdate}

--- a/src/pages/Sites/SiteSettings/Products/hooks/useLabels.js
+++ b/src/pages/Sites/SiteSettings/Products/hooks/useLabels.js
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query'
+import { useLabelCrud } from './useLabelCrud'
+
+export function useLabels(siteName, options = {}) {
+  const { getLabels } = useLabelCrud(siteName)
+  return useQuery({
+    queryKey: ['labels', siteName],
+    queryFn: getLabels,
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}


### PR DESCRIPTION
## Summary
- add useLabels hook for retrieving product labels
- compute label and category options in ProductsList
- pass new options to ProductTable and ProductRow
- allow inline editing of category and labels in the products list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854321c3b68833180e75d449760f4a8