### PR TITLE
Add collapsible sidebars

### DIFF
--- a/src/pages/Sites/SiteSettings/Products/index.jsx
+++ b/src/pages/Sites/SiteSettings/Products/index.jsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import { Menu, X } from 'lucide-react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { useParams } from 'react-router-dom'
@@ -10,6 +11,7 @@ export default function Products() {
   const queryClientRef = useRef(new QueryClient())
   const [selectedCategory, setSelectedCategory] = useState(null)
   const [tab, setTab] = useState('categories')
+  const [sidebarOpen, setSidebarOpen] = useState(false)
   const handleTabChange = (value) => {
     setTab(value)
     if (value === 'categories') setSelectedCategory(null)
@@ -22,8 +24,24 @@ export default function Products() {
     <QueryClientProvider client={queryClientRef.current}>
       <div className="h-full p-4">
         {(tab === 'categories' || tab === 'labels') ? (
-          <div className="flex h-full">
-            <aside className="w-64 border-r bg-white p-4">
+          <div className="relative flex h-full">
+            <button
+              onClick={() => setSidebarOpen(prev => !prev)}
+              className="absolute left-0 top-0 z-20 rounded bg-white p-2 shadow md:hidden"
+            >
+              {sidebarOpen ? <X size={20} /> : <Menu size={20} />}
+            </button>
+
+            {sidebarOpen && (
+              <div
+                className="fixed inset-0 z-10 bg-black/50 backdrop-blur-sm md:hidden"
+                onClick={() => setSidebarOpen(false)}
+              />
+            )}
+
+            <aside
+              className={`fixed inset-y-0 left-0 z-20 w-64 border-r bg-white p-4 transform transition-transform duration-300 md:static md:translate-x-0 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}
+            >
               <CategoryList
                 selected={selectedCategory}
                 onSelect={setSelectedCategory}
@@ -31,7 +49,9 @@ export default function Products() {
                 setTab={handleTabChange}
               />
             </aside>
-            <main className="flex-1 overflow-auto p-4">
+            <main
+              className={`flex-1 overflow-auto p-4 transition-[margin] duration-300 ${sidebarOpen ? 'md:ml-64' : 'ml-0'}`}
+            >
               <ProductsList
                 category={tab === 'categories' ? selectedCategory : null}
                 labels={tab === 'labels' && selectedCategory && selectedCategory !== 'no_label' ? [selectedCategory] : null}

--- a/src/pages/Sites/SiteSettings/index.jsx
+++ b/src/pages/Sites/SiteSettings/index.jsx
@@ -1,4 +1,6 @@
+import { useState } from 'react'
 import { Outlet, NavLink, useParams } from 'react-router-dom'
+import { Menu, X } from 'lucide-react'
 
 export default function SiteSettings() {
   const { domain } = useParams()
@@ -16,18 +18,38 @@ export default function SiteSettings() {
     { label: 'Общие настройки', path: 'general' },
   ]
 
+  const [open, setOpen] = useState(false)
+
   return (
-    <div className="flex h-full">
+    <div className="relative flex h-full">
+      {/* Burger button */}
+      <button
+        onClick={() => setOpen(prev => !prev)}
+        className="absolute left-4 top-4 z-20 rounded bg-white p-2 shadow md:hidden"
+      >
+        {open ? <X size={20} /> : <Menu size={20} />}
+      </button>
+
+      {/* Overlay for mobile */}
+      {open && (
+        <div
+          className="fixed inset-0 z-10 bg-black/50 backdrop-blur-sm md:hidden"
+          onClick={() => setOpen(false)}
+        />
+      )}
+
       {/* Sidebar */}
-      <aside className="w-64 border-r bg-white p-4 space-y-4">
-        <h2 className="text-lg font-bold text-blue-600 mb-4">{full_domain}</h2>
+      <aside
+        className={`fixed inset-y-0 left-0 z-20 w-64 border-r bg-white p-4 space-y-4 transform transition-transform duration-300 md:static md:translate-x-0 ${open ? 'translate-x-0' : '-translate-x-full'}`}
+      >
+        <h2 className="mb-4 text-lg font-bold text-blue-600">{full_domain}</h2>
         <nav className="space-y-2">
           {navItems.map(({ label, path }) => (
             <NavLink
               key={path}
               to={path}
               className={({ isActive }) =>
-                `block px-4 py-2 rounded hover:bg-blue-50 ${
+                `block rounded px-4 py-2 hover:bg-blue-50 ${
                   isActive ? 'bg-blue-100 text-blue-600 font-semibold' : 'text-gray-700'
                 }`
               }
@@ -39,7 +61,9 @@ export default function SiteSettings() {
       </aside>
 
       {/* Content */}
-      <main className="flex-1 p-6 overflow-y-auto">
+      <main
+        className={`flex-1 overflow-y-auto p-6 transition-[margin] duration-300 ${open ? 'md:ml-64' : 'ml-0'}`}
+      >
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
## Summary
- add burger-driven collapsible sidebar for site settings
- enable collapsing category list in Products tab

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685528728e3c833190036439bff30a6b