### PR TITLE
Add Options catalog section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import SiteSettings from './pages/Sites/SiteSettings'
 import Pages from './pages/Sites/SiteSettings/PagesTab'
 import BlocksEditor from './pages/Sites/SiteSettings/PagesTab/BlocksEditor'
 import Products from './pages/Sites/SiteSettings/Catalog/Products'
+import Options from './pages/Sites/SiteSettings/Catalog/Options'
 import Integrations from './pages/Sites/SiteSettings/Integrations'
 import GeneralSettings from './pages/Sites/SiteSettings/GeneralSettings'
 import { SiteSettingsProvider } from './context/SiteSettingsContext'
@@ -34,6 +35,7 @@ export default function App() {
             <Route path="pages" element={<Pages />} />
             <Route path="pages/:slug" element={<BlocksEditor />} />
             <Route path="products" element={<Products />} />
+            <Route path="options" element={<Options />} />
             <Route path="integrations" element={<Integrations />} />
             <Route path="general" element={<GeneralSettings />} />
           </Route>

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/AddGroupModal.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/AddGroupModal.jsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function AddGroupModal({ open, onClose, onSave }) {
+  const [name, setName] = useState('')
+  const [slug, setSlug] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setName('')
+      setSlug('')
+      setLoading(false)
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const handleSave = async () => {
+    const n = name.trim()
+    const s = slug.trim()
+    if (!n || !s) return
+    setLoading(true)
+    try {
+      await onSave({ name: n, slug: s })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Новая группа опций</h3>
+
+        <label className="mb-1 block text-sm">Название</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <label className="mb-1 block text-sm">Slug</label>
+        <input
+          type="text"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!name.trim() || !slug.trim() || loading}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            {loading ? 'Сохранение…' : 'Сохранить'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/AddValueModal.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/AddValueModal.jsx
@@ -1,0 +1,71 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function AddValueModal({ open, onClose, onSave, groupId }) {
+  const [value, setValue] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setValue('')
+      setLoading(false)
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const handleSave = async () => {
+    const v = value.trim()
+    if (!v) return
+    setLoading(true)
+    try {
+      await onSave({ group_id: groupId, value: v })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Новое значение</h3>
+
+        <label className="mb-1 block text-sm">Значение</label>
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!value.trim() || loading}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            {loading ? 'Сохранение…' : 'Сохранить'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/EditGroupModal.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/EditGroupModal.jsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function EditGroupModal({ open, onClose, onSave, group }) {
+  const [name, setName] = useState('')
+  const [slug, setSlug] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (open && group) {
+      setName(group.name || '')
+      setSlug(group.slug || '')
+      setLoading(false)
+    }
+  }, [open, group])
+
+  if (!open || !group) return null
+
+  const handleSave = async () => {
+    const n = name.trim()
+    const s = slug.trim()
+    if (!n || !s) return
+    setLoading(true)
+    try {
+      await onSave({ id: group.id, name: n, slug: s })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Редактировать группу</h3>
+
+        <label className="mb-1 block text-sm">Название</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <label className="mb-1 block text-sm">Slug</label>
+        <input
+          type="text"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!name.trim() || !slug.trim() || loading}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            {loading ? 'Сохранение…' : 'Сохранить'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/EditValueModal.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/EditValueModal.jsx
@@ -1,0 +1,71 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function EditValueModal({ open, onClose, onSave, valueItem }) {
+  const [value, setValue] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (open && valueItem) {
+      setValue(valueItem.value || '')
+      setLoading(false)
+    }
+  }, [open, valueItem])
+
+  if (!open || !valueItem) return null
+
+  const handleSave = async () => {
+    const v = value.trim()
+    if (!v) return
+    setLoading(true)
+    try {
+      await onSave({ id: valueItem.id, group_id: valueItem.group_id, value: v })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Редактировать значение</h3>
+
+        <label className="mb-1 block text-sm">Значение</label>
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!value.trim() || loading}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            {loading ? 'Сохранение…' : 'Сохранить'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/GroupList/GroupList.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/GroupList/GroupList.jsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Plus, Pencil, Trash2 } from 'lucide-react'
+
+import { useOptionGroups } from '../../hooks/useOptionGroups'
+import { useOptionGroupCrud } from '../../hooks/useOptionGroupCrud'
+
+import AddGroupModal from '../AddGroupModal'
+import EditGroupModal from '../EditGroupModal'
+
+export default function GroupList({ selected, onSelect }) {
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
+
+  const { data: groups = [], isFetching, refetch } = useOptionGroups(siteName)
+  const { add, update, remove } = useOptionGroupCrud(siteName)
+
+  const [showAdd, setShowAdd] = useState(false)
+  const [editState, setEditState] = useState({ open: false, group: null })
+
+  return (
+    <div className="relative h-full space-y-4">
+      <div className="flex items-center justify-between px-2 pt-1">
+        <h3 className="font-medium">Группы опций</h3>
+        <button
+          onClick={() => setShowAdd(true)}
+          className="rounded bg-blue-600 px-2 py-1 text-sm text-white hover:bg-blue-700"
+        >
+          <Plus size={16} />
+        </button>
+      </div>
+      <nav className="space-y-1 overflow-y-auto px-2">
+        {groups.map((g) => (
+          <div
+            key={g.id}
+            className={`group flex items-center justify-between rounded px-2 py-1 text-sm cursor-pointer hover:bg-gray-100 ${selected === g.id ? 'bg-blue-100 text-blue-700' : 'text-gray-700'}`}
+            onClick={() => onSelect(g.id)}
+          >
+            <span>{g.name}</span>
+            <span className="flex gap-1 opacity-0 group-hover:opacity-100">
+              <Pencil
+                size={14}
+                className="cursor-pointer hover:text-blue-600"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setEditState({ open: true, group: g })
+                }}
+              />
+              <Trash2
+                size={14}
+                className="cursor-pointer hover:text-red-600"
+                onClick={async (e) => {
+                  e.stopPropagation()
+                  if (window.confirm(`Удалить «${g.name}»?`)) {
+                    await remove.mutateAsync(g.id)
+                  }
+                }}
+              />
+            </span>
+          </div>
+        ))}
+      </nav>
+
+      <AddGroupModal
+        open={showAdd}
+        onClose={() => setShowAdd(false)}
+        onSave={async (payload) => {
+          await add.mutateAsync(payload)
+          setShowAdd(false)
+        }}
+      />
+
+      <EditGroupModal
+        open={editState.open}
+        group={editState.group}
+        onClose={() => setEditState({ open: false, group: null })}
+        onSave={async (payload) => {
+          await update.mutateAsync(payload)
+          setEditState({ open: false, group: null })
+        }}
+      />
+
+      {isFetching && (
+        <div className="absolute inset-x-0 bottom-2 text-center text-xs text-gray-500">Загрузка…</div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/ValueList/ValueList.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/ValueList/ValueList.jsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Plus, Pencil, Trash2 } from 'lucide-react'
+
+import { useOptionValues } from '../../hooks/useOptionValues'
+import { useOptionValueCrud } from '../../hooks/useOptionValueCrud'
+
+import AddValueModal from '../AddValueModal'
+import EditValueModal from '../EditValueModal'
+
+export default function ValueList({ groupId }) {
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
+
+  const { data: values = [], isFetching } = useOptionValues(siteName, groupId)
+  const { add, update, remove } = useOptionValueCrud(siteName)
+
+  const [showAdd, setShowAdd] = useState(false)
+  const [editState, setEditState] = useState({ open: false, value: null })
+
+  if (!groupId) {
+    return <div className="p-4 text-gray-500">Выберите группу</div>
+  }
+
+  return (
+    <div className="relative h-full space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">Значения</h3>
+        <button
+          onClick={() => setShowAdd(true)}
+          className="rounded bg-blue-600 px-2 py-1 text-sm text-white hover:bg-blue-700"
+        >
+          <Plus size={16} />
+        </button>
+      </div>
+
+      <table className="w-full border text-sm">
+        <tbody>
+          {values.map((v) => (
+            <tr key={v.id} className="border-b hover:bg-gray-50">
+              <td className="px-2 py-1">{v.value}</td>
+              <td className="w-16 px-2 py-1 text-right">
+                <span className="flex gap-1 justify-end">
+                  <Pencil
+                    size={14}
+                    className="cursor-pointer hover:text-blue-600"
+                    onClick={() => setEditState({ open: true, value: v })}
+                  />
+                  <Trash2
+                    size={14}
+                    className="cursor-pointer hover:text-red-600"
+                    onClick={async () => {
+                      if (window.confirm('Удалить значение?')) {
+                        await remove.mutateAsync({ id: v.id, group_id: groupId })
+                      }
+                    }}
+                  />
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <AddValueModal
+        open={showAdd}
+        groupId={groupId}
+        onClose={() => setShowAdd(false)}
+        onSave={async (payload) => {
+          await add.mutateAsync(payload)
+          setShowAdd(false)
+        }}
+      />
+
+      <EditValueModal
+        open={editState.open}
+        valueItem={editState.value}
+        onClose={() => setEditState({ open: false, value: null })}
+        onSave={async (payload) => {
+          await update.mutateAsync(payload)
+          setEditState({ open: false, value: null })
+        }}
+      />
+
+      {isFetching && (
+        <div className="absolute inset-x-0 bottom-2 text-center text-xs text-gray-500">Загрузка…</div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionGroupCrud.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionGroupCrud.js
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useOptionGroupCrud(siteName) {
+  const qc = useQueryClient()
+
+  const add = useMutation({
+    mutationFn: async (payload) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/groups`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!res.ok) throw new Error('Ошибка создания группы опций')
+      return res.json()
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['optionGroups', siteName] }),
+  })
+
+  const update = useMutation({
+    mutationFn: async ({ id, ...rest }) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/groups/${id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(rest),
+      })
+      if (!res.ok) throw new Error('Ошибка обновления группы опций')
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['optionGroups', siteName] }),
+  })
+
+  const remove = useMutation({
+    mutationFn: async (id) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/groups/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Ошибка удаления группы опций')
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['optionGroups', siteName] }),
+  })
+
+  return { add, update, remove }
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionGroups.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionGroups.js
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useOptionGroups(siteName, options = {}) {
+  return useQuery({
+    queryKey: ['optionGroups', siteName],
+    queryFn: async () => {
+      const res = await fetch(`${API_URL}/options/${siteName}/groups`, {
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Не удалось получить группы опций')
+      return res.json()
+    },
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionValueCrud.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionValueCrud.js
@@ -1,0 +1,51 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useOptionValueCrud(siteName) {
+  const qc = useQueryClient()
+
+  const add = useMutation({
+    mutationFn: async (payload) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/values`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!res.ok) throw new Error('Ошибка создания значения опции')
+      return res.json()
+    },
+    onSuccess: (_, vars) =>
+      qc.invalidateQueries({ queryKey: ['optionValues', siteName, vars.group_id] }),
+  })
+
+  const update = useMutation({
+    mutationFn: async ({ id, group_id, ...rest }) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/values/${id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(rest),
+      })
+      if (!res.ok) throw new Error('Ошибка обновления значения опции')
+      return res.json().catch(() => null)
+    },
+    onSuccess: (_, vars) =>
+      qc.invalidateQueries({ queryKey: ['optionValues', siteName, vars.group_id] }),
+  })
+
+  const remove = useMutation({
+    mutationFn: async ({ id, group_id }) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/values/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Ошибка удаления значения опции')
+    },
+    onSuccess: (_, vars) =>
+      qc.invalidateQueries({ queryKey: ['optionValues', siteName, vars.group_id] }),
+  })
+
+  return { add, update, remove }
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionValues.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionValues.js
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useOptionValues(siteName, groupId, options = {}) {
+  return useQuery({
+    queryKey: ['optionValues', siteName, groupId],
+    queryFn: async () => {
+      const url = groupId ? `${API_URL}/options/${siteName}/values?group_id=${groupId}` : `${API_URL}/options/${siteName}/values`
+      const res = await fetch(url, { credentials: 'include' })
+      if (!res.ok) throw new Error('Не удалось получить значения опций')
+      return res.json()
+    },
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/index.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/index.jsx
@@ -1,0 +1,28 @@
+import { useRef, useState } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { useParams } from 'react-router-dom'
+
+import GroupList from './components/GroupList/GroupList'
+import ValueList from './components/ValueList/ValueList'
+
+export default function Options() {
+  const queryClientRef = useRef(new QueryClient())
+  const [selectedGroup, setSelectedGroup] = useState(null)
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
+
+  return (
+    <QueryClientProvider client={queryClientRef.current}>
+      <div className="h-full flex">
+        <aside className="w-64 border-r bg-white p-1">
+          <GroupList selected={selectedGroup} onSelect={setSelectedGroup} />
+        </aside>
+        <main className="flex-1 overflow-auto p-4">
+          <ValueList groupId={selectedGroup} />
+        </main>
+      </div>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  )
+}


### PR DESCRIPTION
## Summary
- implement Options catalog section for site settings
- add hooks and components for option groups and values
- wire Options into app routes

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a2c9580c8331bd1ce8f4710ed445