### PR TITLE
Add Options section to site settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import SiteSettings from './pages/Sites/SiteSettings'
 import Pages from './pages/Sites/SiteSettings/PagesTab'
 import BlocksEditor from './pages/Sites/SiteSettings/PagesTab/BlocksEditor'
 import Products from './pages/Sites/SiteSettings/Catalog/Products'
+import Options from './pages/Sites/SiteSettings/Catalog/Options'
 import Integrations from './pages/Sites/SiteSettings/Integrations'
 import GeneralSettings from './pages/Sites/SiteSettings/GeneralSettings'
 import { SiteSettingsProvider } from './context/SiteSettingsContext'
@@ -34,6 +35,7 @@ export default function App() {
             <Route path="pages" element={<Pages />} />
             <Route path="pages/:slug" element={<BlocksEditor />} />
             <Route path="products" element={<Products />} />
+            <Route path="options" element={<Options />} />
             <Route path="integrations" element={<Integrations />} />
             <Route path="general" element={<GeneralSettings />} />
           </Route>

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/AddOptionGroupModal.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/AddOptionGroupModal.jsx
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function AddOptionGroupModal({ open, onClose, onSave }) {
+  const [name, setName] = useState('')
+  const [slug, setSlug] = useState('')
+
+  useEffect(() => {
+    if (!open) {
+      setName('')
+      setSlug('')
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const handleSave = async () => {
+    const n = name.trim()
+    const s = slug.trim()
+    if (!n || !s) return
+    await onSave({ name: n, slug: s })
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Новая группа опций</h3>
+
+        <label className="mb-1 block text-sm">Название</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Введите название"
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="mb-1 block text-sm">Slug</label>
+        <input
+          type="text"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder="Введите slug"
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!name.trim() || !slug.trim()}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Сохранить
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/EditOptionGroupModal.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/EditOptionGroupModal.jsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function EditOptionGroupModal({ open, onClose, onSave, group }) {
+  const [name, setName] = useState('')
+  const [slug, setSlug] = useState('')
+
+  useEffect(() => {
+    if (group && open) {
+      setName(group.name || '')
+      setSlug(group.slug || '')
+    }
+  }, [group, open])
+
+  if (!open || !group) return null
+
+  const handleSave = async () => {
+    const n = name.trim()
+    const s = slug.trim()
+    if (!n || !s) return
+    await onSave({ id: group.id, name: n, slug: s })
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Редактировать группу</h3>
+
+        <label className="mb-1 block text-sm">Название</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <label className="mb-1 block text-sm">Slug</label>
+        <input
+          type="text"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!name.trim() || !slug.trim()}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Сохранить
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionValueModal.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionValueModal.jsx
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function OptionValueModal({ open, onClose, onSave, value }) {
+  const [val, setVal] = useState('')
+
+  useEffect(() => {
+    if (open) {
+      setVal(value?.value || '')
+    }
+  }, [open, value])
+
+  if (!open) return null
+
+  const handleSave = async () => {
+    const v = val.trim()
+    if (!v) return
+    await onSave(v)
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">{value ? 'Редактировать' : 'Новое'} значение</h3>
+
+        <input
+          type="text"
+          value={val}
+          onChange={(e) => setVal(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!val.trim()}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Сохранить
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/BulkActionsBar.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/BulkActionsBar.jsx
@@ -1,0 +1,15 @@
+export default function BulkActionsBar({ count, onDelete }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded border bg-gray-50 px-2 py-1">
+      <span className="text-sm">Выбрано: {count}</span>
+      <div className="ml-auto flex gap-2">
+        <button
+          onClick={onDelete}
+          className="rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500"
+        >
+          Удалить выбранное
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/OptionRow.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/OptionRow.jsx
@@ -1,0 +1,144 @@
+import { useState } from 'react'
+import { Edit2, Trash2, Plus } from 'lucide-react'
+
+export default function OptionRow({
+  group,
+  checked,
+  onCheck,
+  onEdit,
+  onDelete,
+  onAddValue,
+  onEditValue,
+  onDeleteValue,
+  innerRef,
+  draggableProps,
+  dragHandleProps,
+}) {
+  const [editName, setEditName] = useState(false)
+  const [nameVal, setNameVal] = useState('')
+  const [editSlug, setEditSlug] = useState(false)
+  const [slugVal, setSlugVal] = useState('')
+  const [expanded, setExpanded] = useState(false)
+
+  const saveName = async () => {
+    const val = nameVal.trim()
+    setEditName(false)
+    if (val && val !== group.name) await onEdit(group.id, { name: val })
+  }
+
+  const saveSlug = async () => {
+    const val = slugVal.trim()
+    setEditSlug(false)
+    if (val && val !== group.slug) await onEdit(group.id, { slug: val })
+  }
+
+  return (
+    <>
+      <tr
+        ref={innerRef}
+        {...draggableProps}
+        className="hover:bg-gray-50 focus-within:bg-gray-50"
+      >
+        <td className="px-2 py-1" {...dragHandleProps}>
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={() => onCheck(group.id)}
+            className="focus:ring-blue-500"
+          />
+        </td>
+        <td className="px-2 py-1" onDoubleClick={() => { setNameVal(group.name); setEditName(true) }}>
+          {editName ? (
+            <input
+              autoFocus
+              value={nameVal}
+              onChange={(e) => setNameVal(e.target.value)}
+              onBlur={saveName}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') saveName()
+                if (e.key === 'Escape') setEditName(false)
+              }}
+              className="w-full rounded border px-1 text-sm focus:ring-2 focus:ring-blue-500"
+            />
+          ) : (
+            group.name
+          )}
+        </td>
+        <td className="px-2 py-1" onDoubleClick={() => { setSlugVal(group.slug); setEditSlug(true) }}>
+          {editSlug ? (
+            <input
+              autoFocus
+              value={slugVal}
+              onChange={(e) => setSlugVal(e.target.value)}
+              onBlur={saveSlug}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') saveSlug()
+                if (e.key === 'Escape') setEditSlug(false)
+              }}
+              className="w-full rounded border px-1 text-sm focus:ring-2 focus:ring-blue-500"
+            />
+          ) : (
+            group.slug
+          )}
+        </td>
+        <td className="px-2 py-1 text-right space-x-2">
+          <button
+            onClick={() => setExpanded((p) => !p)}
+            className="rounded p-1 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+            title={expanded ? 'Скрыть значения' : 'Показать значения'}
+          >
+            {expanded ? '-' : '+'}
+          </button>
+          <button
+            onClick={() => onEdit(group)}
+            className="rounded p-1 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500"
+            title="Редактировать"
+          >
+            <Edit2 size={16} />
+          </button>
+          <button
+            onClick={() => onDelete(group.id)}
+            className="rounded p-1 hover:bg-gray-100 focus:ring-2 focus:ring-red-500"
+            title="Удалить"
+          >
+            <Trash2 size={16} />
+          </button>
+        </td>
+      </tr>
+      {expanded && (
+        <tr>
+          <td />
+          <td colSpan={3} className="space-y-2 px-2 py-2">
+            <div className="flex flex-wrap gap-2">
+              {group.values.map((v) => (
+                <span
+                  key={v.id}
+                  className="flex items-center gap-1 rounded border px-2 py-1 text-sm"
+                >
+                  <span
+                    onDoubleClick={() => onEditValue(v)}
+                    className="cursor-text"
+                  >
+                    {v.value}
+                  </span>
+                  <button
+                    onClick={() => onDeleteValue(v.id)}
+                    className="rounded p-0.5 text-red-600 hover:bg-red-100"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </span>
+              ))}
+            </div>
+            <button
+              onClick={() => onAddValue(group.id)}
+              className="mt-2 flex items-center gap-1 rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+            >
+              <Plus size={14} /> Добавить значение
+            </button>
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/OptionTable.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/OptionTable.jsx
@@ -1,0 +1,102 @@
+import OptionRow from './OptionRow'
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd'
+
+export default function OptionTable({
+  isFetching,
+  filtered,
+  pageItems,
+  selected,
+  toggleSelect,
+  toggleSelectAll,
+  onEdit,
+  onDelete,
+  onAddValue,
+  onEditValue,
+  onDeleteValue,
+  onReorder,
+}) {
+  const renderBody = () => {
+    if (isFetching) {
+      return (
+        <tbody>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <tr key={i} className="animate-pulse border-t">
+              <td className="px-2 py-3" colSpan={4}>
+                <div className="h-4 w-full rounded bg-gray-200" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      )
+    }
+
+    if (!filtered.length) {
+      return (
+        <tbody>
+          <tr>
+            <td colSpan={4} className="py-6 text-center text-sm text-gray-500">
+              Вы ещё не добавили ни одной группы опций
+            </td>
+          </tr>
+        </tbody>
+      )
+    }
+
+    return (
+      <DragDropContext
+        onDragEnd={({ source, destination }) => {
+          if (!destination || source.index === destination.index) return
+          onReorder(source.index, destination.index)
+        }}
+      >
+        <Droppable droppableId="options">
+          {(prov) => (
+            <tbody ref={prov.innerRef} {...prov.droppableProps}>
+              {pageItems.map((g, index) => (
+                <Draggable key={g.id} draggableId={String(g.id)} index={index}>
+                  {(prov2) => (
+                    <OptionRow
+                      innerRef={prov2.innerRef}
+                      draggableProps={prov2.draggableProps}
+                      dragHandleProps={prov2.dragHandleProps}
+                      group={g}
+                      checked={selected.has(g.id)}
+                      onCheck={toggleSelect}
+                      onEdit={onEdit}
+                      onDelete={onDelete}
+                      onAddValue={onAddValue}
+                      onEditValue={onEditValue}
+                      onDeleteValue={onDeleteValue}
+                    />
+                  )}
+                </Draggable>
+              ))}
+              {prov.placeholder}
+            </tbody>
+          )}
+        </Droppable>
+      </DragDropContext>
+    )
+  }
+
+  return (
+    <table className="w-full border text-left text-sm">
+      <thead className="bg-gray-100">
+        <tr>
+          <th className="w-8 px-2 py-1">
+            <input
+              type="checkbox"
+              onChange={toggleSelectAll}
+              checked={pageItems.length > 0 && pageItems.every((p) => selected.has(p.id))}
+              className="focus:ring-blue-500"
+            />
+          </th>
+          <th className="px-2 py-1">Название</th>
+          <th className="px-2 py-1">Slug</th>
+          <th className="px-2 py-1" />
+        </tr>
+      </thead>
+      {renderBody()}
+    </table>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/OptionsList.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/OptionsList.jsx
@@ -1,0 +1,129 @@
+import { useState, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { useOptions } from '../../hooks/useOptions'
+import { useOptionGroupCrud } from '../../hooks/useOptionGroupCrud'
+import { useOptionValueCrud } from '../../hooks/useOptionValueCrud'
+
+import AddOptionGroupModal from '../AddOptionGroupModal'
+import EditOptionGroupModal from '../EditOptionGroupModal'
+import OptionValueModal from '../OptionValueModal'
+import Toolbar from './Toolbar'
+import BulkActionsBar from './BulkActionsBar'
+import OptionTable from './OptionTable'
+import Pagination from './Pagination'
+import useOptionsList from './useOptionsList'
+
+export default function OptionsList() {
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
+
+  const { data: all = [], isFetching, isError, refetch } = useOptions(siteName)
+  const { add, update, remove } = useOptionGroupCrud(siteName)
+  const { add: addVal, update: updateVal, remove: deleteVal } = useOptionValueCrud(siteName)
+
+  const [ordered, setOrdered] = useState([])
+
+  useEffect(() => {
+    setOrdered(prev => {
+      if (JSON.stringify(prev) !== JSON.stringify(all)) {
+        return all
+      }
+      return prev
+    })
+  }, [all])
+
+  const list = useOptionsList({ options: ordered, removeFn: remove.mutateAsync })
+
+  const [showAdd, setShowAdd] = useState(false)
+  const [edit, setEdit] = useState({ open: false, group: null })
+  const [valueModal, setValueModal] = useState({ open: false, groupId: null, value: null })
+
+  const handleReorder = async (from, to) => {
+    let updated = []
+    setOrdered(prev => {
+      const start = (list.page - 1) * list.pageSize
+      const arr = Array.from(prev)
+      const [moved] = arr.splice(start + from, 1)
+      arr.splice(start + to, 0, moved)
+      updated = arr.map((p, idx) => ({ ...p, order: idx + 1 }))
+      return updated
+    })
+    for (const g of updated) {
+      // eslint-disable-next-line no-await-in-loop
+      await update.mutateAsync({ id: g.id, order: g.order })
+    }
+  }
+
+  if (isError) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-red-600">Не удалось загрузить опции</p>
+        <button
+          onClick={() => refetch()}
+          className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+        >
+          Попробовать снова
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {list.selected.size ? (
+        <BulkActionsBar count={list.selected.size} onDelete={list.deleteSelected} />
+      ) : (
+        <Toolbar onAdd={() => setShowAdd(true)} search={list.search} onSearch={list.setSearch} />
+      )}
+
+      <OptionTable
+        isFetching={isFetching}
+        filtered={list.filtered}
+        pageItems={list.pageItems}
+        selected={list.selected}
+        toggleSelect={list.toggleSelect}
+        toggleSelectAll={list.toggleSelectAll}
+        onEdit={(g) => setEdit({ open: true, group: g })}
+        onDelete={(id) => remove.mutateAsync(id)}
+        onAddValue={(gid) => setValueModal({ open: true, groupId: gid, value: null })}
+        onEditValue={(val) => setValueModal({ open: true, groupId: val.group_id, value: val })}
+        onDeleteValue={(id) => deleteVal.mutateAsync(id)}
+        onReorder={handleReorder}
+      />
+
+      <Pagination page={list.page} totalPages={list.totalPages} setPage={list.setPage} />
+
+      <AddOptionGroupModal
+        open={showAdd}
+        onClose={() => setShowAdd(false)}
+        onSave={async payload => {
+          await add.mutateAsync(payload)
+          setShowAdd(false)
+        }}
+      />
+      <EditOptionGroupModal
+        open={edit.open}
+        group={edit.group}
+        onClose={() => setEdit({ open: false, group: null })}
+        onSave={async payload => {
+          await update.mutateAsync(payload)
+          setEdit({ open: false, group: null })
+        }}
+      />
+      <OptionValueModal
+        open={valueModal.open}
+        value={valueModal.value}
+        onClose={() => setValueModal({ open: false, groupId: null, value: null })}
+        onSave={async (val) => {
+          if (valueModal.value) {
+            await updateVal.mutateAsync({ id: valueModal.value.id, value: val })
+          } else {
+            await addVal.mutateAsync({ group_id: valueModal.groupId, value: val })
+          }
+          setValueModal({ open: false, groupId: null, value: null })
+        }}
+      />
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/Pagination.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/Pagination.jsx
@@ -1,0 +1,32 @@
+export default function Pagination({ page, totalPages, setPage }) {
+  if (totalPages <= 1) return null
+  return (
+    <div className="flex justify-center gap-2 text-sm">
+      <button
+        onClick={() => setPage(p => Math.max(1, p - 1))}
+        disabled={page === 1}
+        className="rounded px-2 py-1 hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+      >
+        &lt;
+      </button>
+      {Array.from({ length: totalPages }).map((_, i) => (
+        <button
+          key={i}
+          onClick={() => setPage(i + 1)}
+          className={`rounded px-2 py-1 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 ${
+            page === i + 1 ? 'bg-blue-600 text-white' : ''
+          }`}
+        >
+          {i + 1}
+        </button>
+      ))}
+      <button
+        onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+        disabled={page === totalPages}
+        className="rounded px-2 py-1 hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+      >
+        &gt;
+      </button>
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/Toolbar.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/Toolbar.jsx
@@ -1,0 +1,21 @@
+import { Plus } from 'lucide-react'
+
+export default function Toolbar({ onAdd, search, onSearch }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        onClick={onAdd}
+        className="flex items-center gap-1 rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500"
+      >
+        <Plus size={16} /> Добавить группу
+      </button>
+      <input
+        type="text"
+        placeholder="Поиск..."
+        value={search}
+        onChange={(e) => onSearch(e.target.value)}
+        className="ml-auto w-48 rounded border px-2 py-1 text-sm focus:ring-2 focus:ring-blue-500"
+      />
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/useOptionsList.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/components/OptionsList/useOptionsList.js
@@ -1,0 +1,74 @@
+import { useEffect, useMemo, useState } from 'react'
+
+export default function useOptionsList({ options = [], removeFn }) {
+  const [search, setSearch] = useState('')
+  const [debounced, setDebounced] = useState('')
+  const [selected, setSelected] = useState(new Set())
+  const [page, setPage] = useState(1)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(search.trim().toLowerCase()), 300)
+    return () => clearTimeout(t)
+  }, [search])
+
+  const filtered = useMemo(() => {
+    let list = options
+    if (debounced) {
+      list = list.filter(o => o.name.toLowerCase().includes(debounced))
+    }
+    return list
+  }, [options, debounced])
+
+  const pageSize = 10
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize))
+  const pageItems = filtered.slice((page - 1) * pageSize, page * pageSize)
+
+  const toggleSelect = (id) => {
+    setSelected(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
+
+  const toggleSelectAll = () => {
+    const ids = pageItems.map(o => o.id)
+    setSelected(prev => {
+      const next = new Set(prev)
+      const allSelected = ids.every(id => next.has(id))
+      if (allSelected) ids.forEach(id => next.delete(id))
+      else ids.forEach(id => next.add(id))
+      return next
+    })
+  }
+
+  const deleteSelected = async () => {
+    for (const id of selected) {
+      // eslint-disable-next-line no-await-in-loop
+      await removeFn(id)
+    }
+    setSelected(new Set())
+  }
+
+  const clearSelected = () => setSelected(new Set())
+
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages)
+  }, [page, totalPages])
+
+  return {
+    search,
+    setSearch,
+    selected,
+    toggleSelect,
+    toggleSelectAll,
+    deleteSelected,
+    clearSelected,
+    page,
+    setPage,
+    pageItems,
+    filtered,
+    totalPages,
+    pageSize,
+  }
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionGroupCrud.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionGroupCrud.js
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useOptionGroupCrud(siteName) {
+  const qc = useQueryClient()
+
+  const add = useMutation({
+    mutationFn: async ({ name, slug }) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/groups`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, slug }),
+      })
+      if (!res.ok) throw new Error('Ошибка создания группы')
+      return res.json()
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['options', siteName] }),
+  })
+
+  const update = useMutation({
+    mutationFn: async ({ id, ...data }) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/groups/${id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) throw new Error('Ошибка обновления группы')
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['options', siteName] }),
+  })
+
+  const remove = useMutation({
+    mutationFn: async (id) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/groups/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Ошибка удаления группы')
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['options', siteName] }),
+  })
+
+  return { add, update, remove }
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionValueCrud.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptionValueCrud.js
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useOptionValueCrud(siteName) {
+  const qc = useQueryClient()
+
+  const add = useMutation({
+    mutationFn: async ({ group_id, value }) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/values`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ group_id, value }),
+      })
+      if (!res.ok) throw new Error('Ошибка создания значения')
+      return res.json()
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['options', siteName] }),
+  })
+
+  const update = useMutation({
+    mutationFn: async ({ id, ...data }) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/values/${id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) throw new Error('Ошибка обновления значения')
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['options', siteName] }),
+  })
+
+  const remove = useMutation({
+    mutationFn: async (id) => {
+      const res = await fetch(`${API_URL}/options/${siteName}/values/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Ошибка удаления значения')
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['options', siteName] }),
+  })
+
+  return { add, update, remove }
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptions.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/hooks/useOptions.js
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useOptions(siteName, options = {}) {
+  return useQuery({
+    queryKey: ['options', siteName],
+    queryFn: async () => {
+      const res = await fetch(`${API_URL}/options/${siteName}/groups`, {
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Не удалось получить опции')
+      return res.json()
+    },
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Options/index.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Options/index.jsx
@@ -1,0 +1,16 @@
+import { useRef } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import OptionsList from './components/OptionsList/OptionsList'
+
+export default function Options() {
+  const queryClientRef = useRef(new QueryClient())
+
+  return (
+    <QueryClientProvider client={queryClientRef.current}>
+      <div className="h-full px-0 pt-0 pb-4">
+        <OptionsList />
+      </div>
+    </QueryClientProvider>
+  )
+}


### PR DESCRIPTION
## Summary
- add Options route and page
- implement option groups CRUD with values
- enable drag-n-drop, pagination, and bulk actions for option groups

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857a380cb408331b84815adf0be7e72