### PR TITLE
Add Extras catalog section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Pages from './pages/Sites/SiteSettings/PagesTab'
 import BlocksEditor from './pages/Sites/SiteSettings/PagesTab/BlocksEditor'
 import Products from './pages/Sites/SiteSettings/Catalog/Products'
 import Options from './pages/Sites/SiteSettings/Catalog/Options'
+import Extras from './pages/Sites/SiteSettings/Catalog/Extras'
 import Integrations from './pages/Sites/SiteSettings/Integrations'
 import GeneralSettings from './pages/Sites/SiteSettings/GeneralSettings'
 import { SiteSettingsProvider } from './context/SiteSettingsContext'
@@ -36,6 +37,7 @@ export default function App() {
             <Route path="pages/:slug" element={<BlocksEditor />} />
             <Route path="products" element={<Products />} />
             <Route path="options" element={<Options />} />
+            <Route path="extras" element={<Extras />} />
             <Route path="integrations" element={<Integrations />} />
             <Route path="general" element={<GeneralSettings />} />
           </Route>

--- a/src/pages/Sites/SiteSettings/Catalog/Extras/components/AddGroupModal.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Extras/components/AddGroupModal.jsx
@@ -1,0 +1,111 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function AddGroupModal({ open, onClose, onSave }) {
+  const [name, setName] = useState('')
+  const [selectionType, setSelectionType] = useState('checkbox')
+  const [minSel, setMinSel] = useState(0)
+  const [maxSel, setMaxSel] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setName('')
+      setSelectionType('checkbox')
+      setMinSel(0)
+      setMaxSel('')
+      setLoading(false)
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const handleSave = async () => {
+    const n = name.trim()
+    if (!n) return
+    setLoading(true)
+    try {
+      await onSave({
+        name: n,
+        selection_type: selectionType,
+        min_selection: parseInt(minSel) || 0,
+        max_selection: maxSel === '' ? null : parseInt(maxSel),
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Новая группа добавок</h3>
+
+        <label className="mb-1 block text-sm">Название</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <label className="mb-1 block text-sm">Тип выбора</label>
+        <select
+          value={selectionType}
+          onChange={(e) => setSelectionType(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        >
+          <option value="checkbox">Множественный</option>
+          <option value="radio">Один из списка</option>
+        </select>
+
+        <label className="mb-1 block text-sm">Мин. выбор</label>
+        <input
+          type="number"
+          value={minSel}
+          onChange={(e) => setMinSel(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <label className="mb-1 block text-sm">Макс. выбор</label>
+        <input
+          type="number"
+          value={maxSel}
+          onChange={(e) => setMaxSel(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!name.trim() || loading}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            {loading ? 'Сохранение…' : 'Сохранить'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Extras/components/AddItemModal.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Extras/components/AddItemModal.jsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function AddItemModal({ open, onClose, onSave, groupId }) {
+  const [name, setName] = useState('')
+  const [price, setPrice] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setName('')
+      setPrice('')
+      setLoading(false)
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const handleSave = async () => {
+    const n = name.trim()
+    const p = parseFloat(price)
+    if (!n || isNaN(p)) return
+    setLoading(true)
+    try {
+      await onSave({ group_id: groupId, name: n, price: p })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Новая добавка</h3>
+
+        <label className="mb-1 block text-sm">Название</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <label className="mb-1 block text-sm">Цена</label>
+        <input
+          type="number"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!name.trim() || price === '' || loading}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            {loading ? 'Сохранение…' : 'Сохранить'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Extras/components/EditGroupModal.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Extras/components/EditGroupModal.jsx
@@ -1,0 +1,112 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function EditGroupModal({ open, onClose, onSave, group }) {
+  const [name, setName] = useState('')
+  const [selectionType, setSelectionType] = useState('checkbox')
+  const [minSel, setMinSel] = useState(0)
+  const [maxSel, setMaxSel] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (open && group) {
+      setName(group.name || '')
+      setSelectionType(group.selection_type || 'checkbox')
+      setMinSel(group.min_selection ?? 0)
+      setMaxSel(group.max_selection ?? '')
+      setLoading(false)
+    }
+  }, [open, group])
+
+  if (!open || !group) return null
+
+  const handleSave = async () => {
+    const n = name.trim()
+    if (!n) return
+    setLoading(true)
+    try {
+      await onSave({
+        id: group.id,
+        name: n,
+        selection_type: selectionType,
+        min_selection: parseInt(minSel) || 0,
+        max_selection: maxSel === '' ? null : parseInt(maxSel),
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Редактировать группу</h3>
+
+        <label className="mb-1 block text-sm">Название</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <label className="mb-1 block text-sm">Тип выбора</label>
+        <select
+          value={selectionType}
+          onChange={(e) => setSelectionType(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        >
+          <option value="checkbox">Множественный</option>
+          <option value="radio">Один из списка</option>
+        </select>
+
+        <label className="mb-1 block text-sm">Мин. выбор</label>
+        <input
+          type="number"
+          value={minSel}
+          onChange={(e) => setMinSel(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <label className="mb-1 block text-sm">Макс. выбор</label>
+        <input
+          type="number"
+          value={maxSel}
+          onChange={(e) => setMaxSel(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!name.trim() || loading}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            {loading ? 'Сохранение…' : 'Сохранить'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Extras/components/EditItemModal.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Extras/components/EditItemModal.jsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const modalRoot =
+  document.getElementById('modal-root') ||
+  (() => {
+    const el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+    return el
+  })()
+
+export default function EditItemModal({ open, onClose, onSave, item }) {
+  const [name, setName] = useState('')
+  const [price, setPrice] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (open && item) {
+      setName(item.name || '')
+      setPrice(item.price?.toString() || '')
+      setLoading(false)
+    }
+  }, [open, item])
+
+  if (!open || !item) return null
+
+  const handleSave = async () => {
+    const n = name.trim()
+    const p = parseFloat(price)
+    if (!n || isNaN(p)) return
+    setLoading(true)
+    try {
+      await onSave({ id: item.id, group_id: item.group_id, name: n, price: p })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 rounded bg-white p-4 shadow-xl">
+        <h3 className="mb-2 text-lg font-medium">Редактировать добавку</h3>
+
+        <label className="mb-1 block text-sm">Название</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="mb-2 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <label className="mb-1 block text-sm">Цена</label>
+        <input
+          type="number"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          className="mb-4 w-full rounded border px-2 py-1 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="rounded px-3 py-1 text-sm hover:bg-gray-100 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            Отмена
+          </button>
+          <button
+            disabled={!name.trim() || price === '' || loading}
+            onClick={handleSave}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50 focus:ring-2 focus:ring-blue-500"
+          >
+            {loading ? 'Сохранение…' : 'Сохранить'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Extras/components/GroupList/GroupList.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Extras/components/GroupList/GroupList.jsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Plus, Pencil, Trash2 } from 'lucide-react'
+
+import { useExtraGroups } from '../../hooks/useExtraGroups'
+import { useExtraGroupCrud } from '../../hooks/useExtraGroupCrud'
+
+import AddGroupModal from '../AddGroupModal'
+import EditGroupModal from '../EditGroupModal'
+
+export default function GroupList({ selected, onSelect }) {
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
+
+  const { data: groups = [], isFetching } = useExtraGroups(siteName)
+  const { add, update, remove } = useExtraGroupCrud(siteName)
+
+  const [showAdd, setShowAdd] = useState(false)
+  const [editState, setEditState] = useState({ open: false, group: null })
+
+  return (
+    <div className="relative h-full space-y-4">
+      <div className="flex items-center justify-between px-2 pt-1">
+        <h3 className="font-medium">Группы добавок</h3>
+        <button
+          onClick={() => setShowAdd(true)}
+          className="rounded bg-blue-600 px-2 py-1 text-sm text-white hover:bg-blue-700"
+        >
+          <Plus size={16} />
+        </button>
+      </div>
+      <nav className="space-y-1 overflow-y-auto px-2">
+        {groups.map((g) => (
+          <div
+            key={g.id}
+            className={`group flex items-center justify-between rounded px-2 py-1 text-sm cursor-pointer hover:bg-gray-100 ${selected === g.id ? 'bg-blue-100 text-blue-700' : 'text-gray-700'}`}
+            onClick={() => onSelect(g.id)}
+          >
+            <span>{g.name}</span>
+            <span className="flex gap-1 opacity-0 group-hover:opacity-100">
+              <Pencil
+                size={14}
+                className="cursor-pointer hover:text-blue-600"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setEditState({ open: true, group: g })
+                }}
+              />
+              <Trash2
+                size={14}
+                className="cursor-pointer hover:text-red-600"
+                onClick={async (e) => {
+                  e.stopPropagation()
+                  if (window.confirm(`Удалить «${g.name}»?`)) {
+                    await remove.mutateAsync(g.id)
+                  }
+                }}
+              />
+            </span>
+          </div>
+        ))}
+      </nav>
+
+      <AddGroupModal
+        open={showAdd}
+        onClose={() => setShowAdd(false)}
+        onSave={async (payload) => {
+          await add.mutateAsync(payload)
+          setShowAdd(false)
+        }}
+      />
+
+      <EditGroupModal
+        open={editState.open}
+        group={editState.group}
+        onClose={() => setEditState({ open: false, group: null })}
+        onSave={async (payload) => {
+          await update.mutateAsync(payload)
+          setEditState({ open: false, group: null })
+        }}
+      />
+
+      {isFetching && (
+        <div className="absolute inset-x-0 bottom-2 text-center text-xs text-gray-500">Загрузка…</div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Extras/components/ItemList/ItemList.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Extras/components/ItemList/ItemList.jsx
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Plus, Pencil, Trash2 } from 'lucide-react'
+
+import { useExtraItems } from '../../hooks/useExtraItems'
+import { useExtraItemCrud } from '../../hooks/useExtraItemCrud'
+
+import AddItemModal from '../AddItemModal'
+import EditItemModal from '../EditItemModal'
+
+export default function ItemList({ groupId }) {
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
+
+  const { data: items = [], isFetching } = useExtraItems(siteName, groupId)
+  const { add, update, remove } = useExtraItemCrud(siteName)
+
+  const [showAdd, setShowAdd] = useState(false)
+  const [editState, setEditState] = useState({ open: false, item: null })
+
+  if (!groupId) {
+    return <div className="p-4 text-gray-500">Выберите группу</div>
+  }
+
+  return (
+    <div className="relative h-full space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">Добавки</h3>
+        <button
+          onClick={() => setShowAdd(true)}
+          className="rounded bg-blue-600 px-2 py-1 text-sm text-white hover:bg-blue-700"
+        >
+          <Plus size={16} />
+        </button>
+      </div>
+
+      <table className="w-full border text-sm">
+        <tbody>
+          {items.map((v) => (
+            <tr key={v.id} className="border-b hover:bg-gray-50">
+              <td className="px-2 py-1">{v.name}</td>
+              <td className="px-2 py-1 w-24 text-right">{v.price}</td>
+              <td className="w-16 px-2 py-1 text-right">
+                <span className="flex gap-1 justify-end">
+                  <Pencil
+                    size={14}
+                    className="cursor-pointer hover:text-blue-600"
+                    onClick={() => setEditState({ open: true, item: v })}
+                  />
+                  <Trash2
+                    size={14}
+                    className="cursor-pointer hover:text-red-600"
+                    onClick={async () => {
+                      if (window.confirm('Удалить значение?')) {
+                        await remove.mutateAsync({ id: v.id, group_id: groupId })
+                      }
+                    }}
+                  />
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <AddItemModal
+        open={showAdd}
+        groupId={groupId}
+        onClose={() => setShowAdd(false)}
+        onSave={async (payload) => {
+          await add.mutateAsync(payload)
+          setShowAdd(false)
+        }}
+      />
+
+      <EditItemModal
+        open={editState.open}
+        item={editState.item}
+        onClose={() => setEditState({ open: false, item: null })}
+        onSave={async (payload) => {
+          await update.mutateAsync(payload)
+          setEditState({ open: false, item: null })
+        }}
+      />
+
+      {isFetching && (
+        <div className="absolute inset-x-0 bottom-2 text-center text-xs text-gray-500">Загрузка…</div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Extras/hooks/useExtraGroupCrud.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Extras/hooks/useExtraGroupCrud.js
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useExtraGroupCrud(siteName) {
+  const qc = useQueryClient()
+
+  const add = useMutation({
+    mutationFn: async (payload) => {
+      const res = await fetch(`${API_URL}/extras/${siteName}/groups`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!res.ok) throw new Error('Ошибка создания группы добавок')
+      return res.json()
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['extraGroups', siteName] }),
+  })
+
+  const update = useMutation({
+    mutationFn: async ({ id, ...rest }) => {
+      const res = await fetch(`${API_URL}/extras/${siteName}/groups/${id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(rest),
+      })
+      if (!res.ok) throw new Error('Ошибка обновления группы добавок')
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['extraGroups', siteName] }),
+  })
+
+  const remove = useMutation({
+    mutationFn: async (id) => {
+      const res = await fetch(`${API_URL}/extras/${siteName}/groups/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Ошибка удаления группы добавок')
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['extraGroups', siteName] }),
+  })
+
+  return { add, update, remove }
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Extras/hooks/useExtraGroups.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Extras/hooks/useExtraGroups.js
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useExtraGroups(siteName, options = {}) {
+  return useQuery({
+    queryKey: ['extraGroups', siteName],
+    queryFn: async () => {
+      const res = await fetch(`${API_URL}/extras/${siteName}/groups`, {
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Не удалось получить группы добавок')
+      return res.json()
+    },
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Extras/hooks/useExtraItemCrud.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Extras/hooks/useExtraItemCrud.js
@@ -1,0 +1,51 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useExtraItemCrud(siteName) {
+  const qc = useQueryClient()
+
+  const add = useMutation({
+    mutationFn: async (payload) => {
+      const res = await fetch(`${API_URL}/extras/${siteName}/items`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!res.ok) throw new Error('Ошибка создания элемента добавки')
+      return res.json()
+    },
+    onSuccess: (_, vars) =>
+      qc.invalidateQueries({ queryKey: ['extraItems', siteName, vars.group_id] }),
+  })
+
+  const update = useMutation({
+    mutationFn: async ({ id, group_id, ...rest }) => {
+      const res = await fetch(`${API_URL}/extras/${siteName}/items/${id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(rest),
+      })
+      if (!res.ok) throw new Error('Ошибка обновления элемента добавки')
+      return res.json().catch(() => null)
+    },
+    onSuccess: (_, vars) =>
+      qc.invalidateQueries({ queryKey: ['extraItems', siteName, vars.group_id] }),
+  })
+
+  const remove = useMutation({
+    mutationFn: async ({ id, group_id }) => {
+      const res = await fetch(`${API_URL}/extras/${siteName}/items/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Ошибка удаления элемента добавки')
+    },
+    onSuccess: (_, vars) =>
+      qc.invalidateQueries({ queryKey: ['extraItems', siteName, vars.group_id] }),
+  })
+
+  return { add, update, remove }
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Extras/hooks/useExtraItems.js
+++ b/src/pages/Sites/SiteSettings/Catalog/Extras/hooks/useExtraItems.js
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export function useExtraItems(siteName, groupId, options = {}) {
+  return useQuery({
+    queryKey: ['extraItems', siteName, groupId],
+    queryFn: async () => {
+      const url = groupId
+        ? `${API_URL}/extras/${siteName}/items?group_id=${groupId}`
+        : `${API_URL}/extras/${siteName}/items`
+      const res = await fetch(url, { credentials: 'include' })
+      if (!res.ok) throw new Error('Не удалось получить элементы добавок')
+      return res.json()
+    },
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}

--- a/src/pages/Sites/SiteSettings/Catalog/Extras/index.jsx
+++ b/src/pages/Sites/SiteSettings/Catalog/Extras/index.jsx
@@ -1,0 +1,29 @@
+import { useRef, useState } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { useParams } from 'react-router-dom'
+
+import GroupList from './components/GroupList/GroupList'
+import ItemList from './components/ItemList/ItemList'
+
+export default function Extras() {
+  const queryClientRef = useRef(new QueryClient())
+  const [selectedGroup, setSelectedGroup] = useState(null)
+  const { domain } = useParams()
+  const siteName = `${domain}_app`
+
+  return (
+    <QueryClientProvider client={queryClientRef.current}>
+      <div className="h-full flex">
+        <aside className="w-64 border-r bg-white p-1">
+          <GroupList selected={selectedGroup} onSelect={setSelectedGroup} />
+        </aside>
+        <main className="flex-1 overflow-auto p-4">
+          <ItemList groupId={selectedGroup} />
+        </main>
+      </div>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  )
+}
+

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/preview/BlockDetails.jsx
@@ -27,12 +27,27 @@ export default function BlockDetails({ block, data, onSave, onBlockChange }) {
   useEffect(() => {
     if (!block?.real_id) return
 
+    let parsedSettings = {}
+    let parsedData = {}
+
+    try {
+      parsedSettings = typeof block.settings === 'string' ? JSON.parse(block.settings) : block.settings || {}
+    } catch (err) {
+      console.warn('❌ Ошибка парсинга block.settings:', err)
+    }
+
+    try {
+      parsedData = typeof block.data === 'string' ? JSON.parse(block.data) : block.data || {}
+    } catch (err) {
+      console.warn('❌ Ошибка парсинга block.data:', err)
+    }
+
     const combinedSettings = {
-      ...(typeof block.settings === 'string' ? JSON.parse(block.settings) : block.settings || {}),
+      ...parsedSettings,
       ...(data?.settings || {}),
     }
     const combinedData = {
-      ...(block.data || {}),
+      ...parsedData,
       ...(data?.data || {}),
     }
 
@@ -70,7 +85,7 @@ export default function BlockDetails({ block, data, onSave, onBlockChange }) {
     const previewProps = { settings: form.settings || form }
 
     if (block.type === 'navigation') {
-      previewProps.settings = {  block_id: form.block_id, ...(form.settings || {}) }
+      previewProps.settings = { block_id: form.block_id, ...(form.settings || {}) }
     }
 
     if (block.type === 'header') {

--- a/src/pages/Sites/SiteSettings/index.jsx
+++ b/src/pages/Sites/SiteSettings/index.jsx
@@ -23,7 +23,7 @@ export default function SiteSettings() {
   const [catalogOpen, setCatalogOpen] = useState(
     location.pathname.includes('/products') ||
     location.pathname.includes('/options') ||
-    location.pathname.includes('/addons')
+    location.pathname.includes('/extras')
   )
 
   const containerSuffix = import.meta.env.VITE_CONTAINER_SUFFIX
@@ -123,7 +123,7 @@ export default function SiteSettings() {
                   </NavLink>
 
                   <NavLink
-                    to="addons"
+                    to="extras"
                     className={({ isActive }) =>
                       `flex items-center gap-2 py-1 rounded hover:bg-blue-50 text-sm transition-colors ${
                         isActive ? 'bg-blue-100 text-blue-600 font-semibold' : 'text-gray-700'


### PR DESCRIPTION
## Summary
- implement Extras catalog pages cloned from Options but adjusted
- wire up Extras route and navigation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857a8812d94833198eec4e5c590017d