### PR TITLE
Update preview image urls

### DIFF
--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Delivery.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Delivery/Delivery.jsx
@@ -1,4 +1,5 @@
 import mapImage from '/images/7.webp'
+import { getImageVariants } from '@/utils/imageVariants'
 
 export const Delivery = ({ settings = {}, data = {}, commonSettings = {} }) => {
   const bg = settings.background_color ?? commonSettings.background?.base ?? '#FFFFFF'
@@ -38,10 +39,12 @@ export const Delivery = ({ settings = {}, data = {}, commonSettings = {} }) => {
   const mapTitle = data.map_title || 'ЗОНА ДОСТАВКИ ОГРАНИЧЕНА'
 
   const assetsBase = import.meta.env.VITE_ASSETS_URL || ''
-  const mapUrl =
+  const mapFullPath =
     data.map_image && data.map_image.startsWith('/')
       ? `${assetsBase}${data.map_image}`
-      : data.map_image || mapImage
+      : data.map_image || ''
+  const { small: mapUrlSmall } = getImageVariants(mapFullPath)
+  const mapUrl = mapFullPath ? mapUrlSmall : mapImage
 
   return (
     <div

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Header.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Header/Header.jsx
@@ -2,6 +2,7 @@
 
 import { LogIn, Star, CircleDollarSign, Menu, X } from 'lucide-react'
 import { useState } from 'react'
+import { getImageVariants } from '@/utils/imageVariants'
 
 export const Header = ({ settings = {}, data = {}, commonSettings = {}, navigation }) => {
   const [mobileOpen, setMobileOpen] = useState(false)
@@ -18,7 +19,9 @@ export const Header = ({ settings = {}, data = {}, commonSettings = {}, navigati
 
   const rawLogoPath = data.logo_url || '/images/logo.webp'
   const baseUrl = import.meta.env.VITE_LIBRARY_ASSETS_URL || ''
-  const logoUrl = rawLogoPath.startsWith('/') ? `${baseUrl}${rawLogoPath}_small.webp` : rawLogoPath
+  const fullLogoPath = rawLogoPath.startsWith('/') ? baseUrl + rawLogoPath : rawLogoPath
+  const { small } = getImageVariants(fullLogoPath)
+  const logoUrl = fullLogoPath ? small : rawLogoPath
 
   const subtitle = data.subtitle || 'Описание'
   const city = data.city || 'Город'

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItems.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PopularItems/PopularItems.jsx
@@ -1,4 +1,5 @@
 import pizzaImg from '/images/8.webp'
+import { getImageVariants } from '@/utils/imageVariants'
 
 export const PopularItems = ({ settings = {}, data = {}, commonSettings = {} }) => {
   const backgroundColor = settings.bg_color ?? commonSettings.background?.card ?? '#FFFFFF'
@@ -87,7 +88,15 @@ export const PopularItems = ({ settings = {}, data = {}, commonSettings = {} }) 
               }}
             />
             <img
-              src={item.img_url ? (item.img_url.startsWith('/') ? baseUrl + item.img_url : item.img_url) : pizzaImg}
+              src={(() => {
+                const fullPath = item.img_url
+                  ? item.img_url.startsWith('/')
+                    ? baseUrl + item.img_url
+                    : item.img_url
+                  : ''
+                const { small } = getImageVariants(fullPath)
+                return fullPath ? small : pizzaImg
+              })()}
               alt={item.name}
               className={`${imageSize} object-cover`}
             />

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/PromoCards.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/PromoCards/PromoCards.jsx
@@ -1,5 +1,6 @@
 import pizzaImg from '/images/9.webp'
 import { useRef } from 'react'
+import { getImageVariants } from '@/utils/imageVariants'
 
 export const PromoCards = ({ settings = {}, data = {}, commonSettings = {} }) => {
   const bg_color = settings.bg_color ?? commonSettings.background?.card ?? '#FFFFFF'
@@ -105,11 +106,13 @@ export const PromoCards = ({ settings = {}, data = {}, commonSettings = {} }) =>
         style={{ gap: `${gap}px`, WebkitOverflowScrolling: 'touch' }}
       >
         {cards.map((card) => {
-          const imageUrl = card.img_url
+          const fullPath = card.img_url
             ? card.img_url.startsWith('/')
               ? baseUrl + card.img_url
               : card.img_url
-            : pizzaImg
+            : ''
+          const { small } = getImageVariants(fullPath)
+          const imageUrl = fullPath ? small : pizzaImg
           return (
           <div key={card.id} style={{ perspective: '1000px' }}>
             <div style={{ paddingTop: `${card_padding}px`, paddingBottom: `${card_padding}px` }}>

--- a/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Reviews.jsx
+++ b/src/pages/Sites/SiteSettings/PagesTab/BlocksEditor/forms/Reviews/Reviews.jsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useState } from 'react'
 import pizzaImg from '/images/6.webp'
+import { getImageVariants } from '@/utils/imageVariants'
 import { defaultReviews } from './reviewsDataSchema'
 
 export const Reviews = ({ settings = {}, data = {}, commonSettings = {} }) => {
@@ -167,8 +168,24 @@ export const Reviews = ({ settings = {}, data = {}, commonSettings = {} }) => {
             >
               <div className="flex items-center gap-3 mb-2">
                 <img
-                  src={review.img_url && review.img_url.startsWith('/') ? `${assetsBase}${review.img_url}` : review.img_url || pizzaImg}
-                  data-src={review.img_url && review.img_url.startsWith('/') ? `${assetsBase}${review.img_url}` : review.img_url || pizzaImg}
+                  src={(() => {
+                    const fullPath = review.img_url
+                      ? review.img_url.startsWith('/')
+                        ? assetsBase + review.img_url
+                        : review.img_url
+                      : ''
+                    const { small } = getImageVariants(fullPath)
+                    return fullPath ? small : pizzaImg
+                  })()}
+                  data-src={(() => {
+                    const fullPath = review.img_url
+                      ? review.img_url.startsWith('/')
+                        ? assetsBase + review.img_url
+                        : review.img_url
+                      : ''
+                    const { small } = getImageVariants(fullPath)
+                    return fullPath ? small : pizzaImg
+                  })()}
                   alt={review.name}
                   className="object-cover rounded-full border"
                   style={{ width: avatarSize, height: avatarSize }}


### PR DESCRIPTION
## Summary
- use `getImageVariants` for preview images in Header, Delivery, PromoCards, PopularItems and Reviews blocks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6878fc52044c83319215211c711ef538